### PR TITLE
Fix role counters not displaying correct data

### DIFF
--- a/__mocks__/data/testContent.js
+++ b/__mocks__/data/testContent.js
@@ -10,6 +10,8 @@ export default {
   },
   media: {
     media_files: 9,
+    activeCurators: 3,
+    channels: 20
   },
   memberships: {
     platform_members: 164,

--- a/__tests__/pages/__snapshots__/acropolis.test.js.snap
+++ b/__tests__/pages/__snapshots__/acropolis.test.js.snap
@@ -168,11 +168,14 @@ exports[`AcropolisPage page renders correctly 1`] = `
         <RoleList
           content={
             Object {
+              "contentCreatorsCount": 20,
+              "contentCuratorsCount": 3,
               "councilMembersCount": 12,
               "storageProviders": 10,
               "validatorsCount": 20,
             }
           }
+          oldTestnet={true}
           roles={
             Array [
               Object {

--- a/__tests__/pages/__snapshots__/athens.test.js.snap
+++ b/__tests__/pages/__snapshots__/athens.test.js.snap
@@ -227,11 +227,14 @@ exports[`AthensPage page renders correctly 1`] = `
         <RoleList
           content={
             Object {
+              "contentCreatorsCount": 20,
+              "contentCuratorsCount": 3,
               "councilMembersCount": 12,
               "storageProviders": 10,
               "validatorsCount": 20,
             }
           }
+          oldTestnet={true}
           roles={
             Array [
               Object {

--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -184,6 +184,8 @@ exports[`IndexPage page renders correctly 1`] = `
         <RoleList
           content={
             Object {
+              "contentCreatorsCount": 20,
+              "contentCuratorsCount": 3,
               "councilMembersCount": 12,
               "storageProviders": 10,
               "validatorsCount": 20,
@@ -244,6 +246,8 @@ exports[`IndexPage page renders correctly 1`] = `
         <RoleList
           content={
             Object {
+              "contentCreatorsCount": 20,
+              "contentCuratorsCount": 3,
               "councilMembersCount": 12,
               "storageProviders": 10,
               "validatorsCount": 20,

--- a/__tests__/pages/__snapshots__/rome.test.js.snap
+++ b/__tests__/pages/__snapshots__/rome.test.js.snap
@@ -161,11 +161,14 @@ exports[`RomePage page renders correctly 1`] = `
         <RoleList
           content={
             Object {
+              "contentCreatorsCount": 20,
+              "contentCuratorsCount": 3,
               "councilMembersCount": 12,
               "storageProviders": 10,
               "validatorsCount": 20,
             }
           }
+          oldTestnet={true}
           roles={
             Array [
               Object {

--- a/__tests__/pages/__snapshots__/sparta.test.js.snap
+++ b/__tests__/pages/__snapshots__/sparta.test.js.snap
@@ -166,11 +166,14 @@ exports[`SpartaPage page renders correctly 1`] = `
         <RoleList
           content={
             Object {
+              "contentCreatorsCount": 20,
+              "contentCuratorsCount": 3,
               "councilMembersCount": 12,
               "storageProviders": 10,
               "validatorsCount": 20,
             }
           }
+          oldTestnet={true}
           roles={
             Array [
               Object {

--- a/src/components/RoleCard/index.js
+++ b/src/components/RoleCard/index.js
@@ -37,7 +37,7 @@ const contentTypes = {
   most: number => <>At most, {numberWrapper(number)} users occupied this role</>,
 };
 
-const RoleCard = ({ image: Image, title, count, type, className, hasLabel, ...props }) => {
+const RoleCard = ({ image: Image, title, count, type, className, hasLabel, oldTestnet, ...props }) => {
   const classes = cn('RoleCard', className, {
     'RoleCard--labeled': hasLabel,
     'RoleCard--small': !count,
@@ -47,7 +47,7 @@ const RoleCard = ({ image: Image, title, count, type, className, hasLabel, ...pr
       <Image className="RoleCard__image" />
       <div className="RoleCard__content">
         <p className="RoleCard__title">{title}</p>
-        {count && (
+        {(!oldTestnet && count) && (
           <p className="RoleCard__info">
             <PeopleIcon className="RoleCard__icon" />
             {contentTypes[type](count)}

--- a/src/components/RoleList/index.js
+++ b/src/components/RoleList/index.js
@@ -7,12 +7,12 @@ const propTypes = {
   content: object.isRequired,
 };
 
-const RoleList = ({ roles, content }) => {
+const RoleList = ({ roles, content, oldTestnet }) => {
   return (
     <>
       {roles.map(role => {
         const count = role.key ? content[role.key] || '-' : role.count;
-        return <RoleCard {...role} key={role.title} count={count} />;
+        return <RoleCard {...role} key={role.title} count={count} oldTestnet={oldTestnet} />;
       })}
     </>
   );

--- a/src/components/_enhancers/withApi.js
+++ b/src/components/_enhancers/withApi.js
@@ -18,14 +18,14 @@ export default function withApi(WrappedComponent, apiPath) {
     }
 
     getData = async () => {
-      const apiUrl = process.env.GATSBY_API_URL;
+      const apiUrl = process.env.GATSBY_API_URL || "https://status.joystream.app/";
 
       if (!apiUrl) {
         return;
       }
 
       try {
-        const content = await axios.get(`${apiUrl}${apiPath}`);
+        const content = await axios.get(`${apiUrl}`);
 
         if (this.mounted) {
           this.setState({

--- a/src/pages/acropolis/index.js
+++ b/src/pages/acropolis/index.js
@@ -121,7 +121,7 @@ const AcropolisPage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Roles available on this testnet">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} oldTestnet/>
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>

--- a/src/pages/alexandria/index.js
+++ b/src/pages/alexandria/index.js
@@ -113,7 +113,7 @@ const AlexandriaPage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Incentivized Roles for the Alexandria Network">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} oldTestnet />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>

--- a/src/pages/athens/index.js
+++ b/src/pages/athens/index.js
@@ -113,7 +113,7 @@ const AthensPage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Roles available on the current testnet">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} oldTestnet />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>

--- a/src/pages/constantinople/index.js
+++ b/src/pages/constantinople/index.js
@@ -111,7 +111,7 @@ const ConstantinoplePage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Incentivized Roles for the Constantinople Network">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} oldTestnet />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>

--- a/src/pages/rome/index.js
+++ b/src/pages/rome/index.js
@@ -108,7 +108,7 @@ const RomePage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Incentivized Roles for the Rome Network">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} oldTestnet />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>

--- a/src/pages/sparta/index.js
+++ b/src/pages/sparta/index.js
@@ -84,7 +84,7 @@ const SpartaPage = ({ content }) => {
       <LayoutWrapper dark>
         <TitleWrapper title="Roles available on the Sparta testnet">
           <ColumnsLayout>
-            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} />
+            <RoleList roles={roles.active} content={mapStatusDataToRoles(content)} oldTestnet />
           </ColumnsLayout>
         </TitleWrapper>
       </LayoutWrapper>

--- a/src/pages/token/index.js
+++ b/src/pages/token/index.js
@@ -121,7 +121,7 @@ const TokensPage = () => {
         <div className="TokensPage__disclaimer-text">
           <p>
             This disclaimer applies to the webpage accessible at{' '}
-            <a href="www.joystream.org/token">www.joystream.org/token</a> as well as all other webpages, digital
+            <a href="https://www.joystream.org/token">www.joystream.org/token</a> as well as all other webpages, digital
             services or applications published by Jsgenesis (the “Company”). The disclaimer also applies to any material
             published by Company in any other format in connection with the JOY token (the “Token”). Publications made
             by Company and all information contained within them are not directed at or intended for use by any person

--- a/src/utils/mapStatusDataToRoles/index.js
+++ b/src/utils/mapStatusDataToRoles/index.js
@@ -4,6 +4,8 @@ const keys = {
   validatorsCount: 'validators.count',
   councilMembersCount: 'council.members_count',
   storageProviders: 'roles.storage_providers',
+  contentCuratorsCount: 'media.activeCurators',
+  contentCreatorsCount: 'media.channels'
 };
 
 const mapStatusDataToRoles = data => {

--- a/src/utils/useAxios/index.js
+++ b/src/utils/useAxios/index.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import usePromise from '../usePromise';
 
-const defaultUrl = process.env.GATSBY_API_URL || 'https://status.joystream.app/status';
+const defaultUrl = process.env.GATSBY_API_URL || 'https://status.joystream.app';
 
 export default function useAxios(url = defaultUrl) {
   const [response, loading, error] = usePromise(() => axios.get(url));


### PR DESCRIPTION
This PR address this issue: https://github.com/Joystream/joystream-org/issues/228

I've removed the counter on old testnets and added the functionality for content curators and creators on the current one.