### PR TITLE
Non-FM Avatar Loading

### DIFF
--- a/src/pages/founding-members/components/Metrics/index.js
+++ b/src/pages/founding-members/components/Metrics/index.js
@@ -1,13 +1,15 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Table from '../../../../components/Table';
 import { ArrowButton } from '../../index';
 import { ReactComponent as Achieved } from '../../../../assets/svg/achieved.svg';
 import calculateTokensAllocated from '../../../../utils/calculateTokensAllocated';
-import { Link } from 'gatsby';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { types } from '@joystream/types';
+import { JoystreamWSProvider } from '../../../../data/pages/founding-members'
 
 import './style.scss';
 
-const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
+const MetricsRowFoundingData = ({ data, partialTokenAllocation }) => {
   const [imageHasError, setImageHasError] = useState(false);
 
   return (
@@ -18,16 +20,14 @@ const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
             <img
               className="FoundingMembersPage__leaderboard__main__placeholder"
               src={data?.inducted?.avatar}
-              alt="icon of founding member"
+              alt=""
               onError={() => {
                 setImageHasError(true);
               }}
             />
-            {founding && (
-              <div className="FoundingMembersPage__leaderboard__main__checkmark">
-                <Achieved />
-              </div>
-            )}
+            <div className="FoundingMembersPage__leaderboard__main__checkmark">
+              <Achieved />
+            </div>
           </>
         ) : (
           <div className="FoundingMembersPage__leaderboard__main__placeholder"></div>
@@ -36,13 +36,9 @@ const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
           <p className="FoundingMembersPage__leaderboard__main__name">@{data?.memberHandle}</p>
         </div>
       </div>
-      {founding && (
-        <div style={{ justifySelf: 'center' }} className="FoundingMembersPage__leaderboard__score">
-          <p>
-            {calculateTokensAllocated(data?.extraAllocation, data?.totalScore, partialTokenAllocation)}
-          </p>
-        </div>
-      )}
+      <div style={{ justifySelf: 'center' }} className="FoundingMembersPage__leaderboard__score">
+        <p>{calculateTokensAllocated(data?.extraAllocation, data?.totalScore, partialTokenAllocation)}</p>
+      </div>
       <div className="FoundingMembersPage__leaderboard__score">
         <p>{data?.totalScore}</p>
       </div>
@@ -50,97 +46,154 @@ const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
   );
 };
 
-const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, partialTokenAllocation }) => (
-  <>
-    <div className="FoundingMembersPage__metrics">
-      <h2 className="FoundingMembersPage__metrics__title">Key metrics for the program</h2>
-      <div className="FoundingMembersPage__metrics__list">
-        <div>
-          <p className="FoundingMembersPage__metrics__stat">{sizeOfFirstTokenPool && `${sizeOfFirstTokenPool}%`}</p>
-          <p className="FoundingMembersPage__metrics__text">size of initial token pool</p>
-        </div>
-        {/* <div>
-          <p className="FoundingMembersPage__metrics__stat">71%</p>
-          <p className="FoundingMembersPage__metrics__text">size of second token pool</p>
-        </div> */}
-        <div>
-          <p className="FoundingMembersPage__metrics__stat">{foundingMembers?.length}</p>
-          <p className="FoundingMembersPage__metrics__text">number of founding members</p>
-        </div>
-        <div>
-          <p className="FoundingMembersPage__metrics__stat">
-            {nonFoundingMembers && nonFoundingMembers.filter(member => member.totalDirectScore > 0).length}
-          </p>
-          <p className="FoundingMembersPage__metrics__text">number of founding member candidates</p>
+const MetricsRowNonFoundingData = ({ data, Api }) => {
+  const [image, setImage] = useState();
+  const [imageIsReady, setImageIsReady] = useState(false);
+
+  useEffect(() => {
+    async function getImage() {
+      if(data?.memberId && Api) {
+        setImage((await Api.query.members.membershipById(data?.memberId)).avatar_uri);
+      }
+    }
+    getImage();
+  }, [Api]);
+
+  useEffect(() => {
+    if(image) {
+      const img = new Image();
+      img.addEventListener('load',() => {
+        setImageIsReady(true);
+      });
+      img.src = image;
+    }
+  }, [image]);
+
+  return (
+    <>
+      <div className="FoundingMembersPage__leaderboard__main">
+        {imageIsReady ? (
+          <>
+            <img
+              className="FoundingMembersPage__leaderboard__main__placeholder"
+              src={image}
+              alt=""
+            />
+          </>
+        ) : (
+          <div className="FoundingMembersPage__leaderboard__main__placeholder"></div>
+        )}
+        <div className="FoundingMembersPage__leaderboard__main__data">
+          <p className="FoundingMembersPage__leaderboard__main__name">@{data?.memberHandle}</p>
         </div>
       </div>
-    </div>
-    <div className="FoundingMembersPage__leaderboards">
-      <div className="FoundingMembersPage__leaderboard-left">
-        <h3 className="FoundingMembersPage__leaderboards__title">Leaderboards</h3>
+      <div className="FoundingMembersPage__leaderboard__score">
+        <p>{data?.totalScore}</p>
+      </div>
+    </>
+  );
+};
+
+const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, partialTokenAllocation }) => {
+  const [Api, setApi] = useState();
+
+  useEffect(() => {
+    async function setUpApi() {
+      const provider = new WsProvider(JoystreamWSProvider);
+      const api = await ApiPromise.create({ provider, types });
+      await api.isReady;
+      setApi(api);
+    }
+    setUpApi();
+  }, []);
+
+  return (
+    <>
+      <div className="FoundingMembersPage__metrics">
+        <h2 className="FoundingMembersPage__metrics__title">Key metrics for the program</h2>
+        <div className="FoundingMembersPage__metrics__list">
+          <div>
+            <p className="FoundingMembersPage__metrics__stat">{sizeOfFirstTokenPool && `${sizeOfFirstTokenPool}%`}</p>
+            <p className="FoundingMembersPage__metrics__text">size of initial token pool</p>
+          </div>
+          <div>
+            <p className="FoundingMembersPage__metrics__stat">{foundingMembers?.length}</p>
+            <p className="FoundingMembersPage__metrics__text">number of founding members</p>
+          </div>
+          <div>
+            <p className="FoundingMembersPage__metrics__stat">
+              {nonFoundingMembers && nonFoundingMembers.filter(member => member.totalDirectScore > 0).length}
+            </p>
+            <p className="FoundingMembersPage__metrics__text">number of founding member candidates</p>
+          </div>
+        </div>
+      </div>
+      <div className="FoundingMembersPage__leaderboards">
+        <div className="FoundingMembersPage__leaderboard-left">
+          <h3 className="FoundingMembersPage__leaderboards__title">Leaderboards</h3>
+          <div className="FoundingMembersPage__leaderboard-wrapper">
+            <h4 className="FoundingMembersPage__leaderboard__title">Founding Members</h4>
+            <Table className="FoundingMembersPage__leaderboard">
+              <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--founding">
+                <Table.HeaderItem></Table.HeaderItem>
+                <Table.HeaderItem textAlign="center">Tokens allocated / projected</Table.HeaderItem>
+                <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
+              </Table.Header>
+              <Table.Body className="FoundingMembersPage__leaderboard__body">
+                {foundingMembers?.map((foundingMember, index) => (
+                  <Table.Row
+                    key={index}
+                    className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--founding"
+                  >
+                    <MetricsRowFoundingData
+                      key={index}
+                      data={foundingMember}
+                      partialTokenAllocation={partialTokenAllocation}
+                    />
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table>
+            <ArrowButton
+              className="FoundingMembersPage__leaderboard__button"
+              link="/founding-members/leaderboards"
+              text="All Founding Member Scores"
+            />
+          </div>
+        </div>
         <div className="FoundingMembersPage__leaderboard-wrapper">
-          <h4 className="FoundingMembersPage__leaderboard__title">Founding Members</h4>
+          <h4 className="FoundingMembersPage__leaderboard__title">Non-Founding Members</h4>
           <Table className="FoundingMembersPage__leaderboard">
-            <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--founding">
+            <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--nonfounding">
               <Table.HeaderItem></Table.HeaderItem>
-              <Table.HeaderItem textAlign="center">Tokens allocated / projected</Table.HeaderItem>
               <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
             </Table.Header>
             <Table.Body className="FoundingMembersPage__leaderboard__body">
-              {foundingMembers?.map((foundingMember, index) => (
+              {nonFoundingMembers?.map((nonFoundingMember, index) => (
                 <Table.Row
                   key={index}
-                  className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--founding"
+                  className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--nonfounding"
                 >
-                  <MetricsRowData
-                    key={index}
-                    data={foundingMember}
-                    partialTokenAllocation={partialTokenAllocation}
-                    founding
-                  />
+                  <MetricsRowNonFoundingData key={index} data={nonFoundingMember} Api={Api} />
                 </Table.Row>
               ))}
             </Table.Body>
           </Table>
           <ArrowButton
             className="FoundingMembersPage__leaderboard__button"
-            link="/founding-members/leaderboards"
-            text="All Founding Member Scores"
+            to="/founding-members/leaderboards"
+            text="All Regular Member Scores"
+            state={{ isFoundingMember: false }}
           />
         </div>
-      </div>
-      <div className="FoundingMembersPage__leaderboard-wrapper">
-        <h4 className="FoundingMembersPage__leaderboard__title">Non-Founding Members</h4>
-        <Table className="FoundingMembersPage__leaderboard">
-          <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--nonfounding">
-            <Table.HeaderItem></Table.HeaderItem>
-            <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
-          </Table.Header>
-          <Table.Body className="FoundingMembersPage__leaderboard__body">
-            {nonFoundingMembers?.map((foundingMember, index) => (
-              <Table.Row
-                key={index}
-                className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--nonfounding"
-              >
-                <MetricsRowData key={index} data={foundingMember} />
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
         <ArrowButton
-          className="FoundingMembersPage__leaderboard__button"
-          to="/founding-members/leaderboards"
-          text="All Regular Member Scores"
-          state={{ isFoundingMember: false }}
+          className="FoundingMembersPage__leaderboards__button"
+          link="https://github.com/Joystream/founding-members/blob/main/RULES.md"
+          text="Read the full program rules"
         />
       </div>
-      <ArrowButton
-        className="FoundingMembersPage__leaderboards__button"
-        link="https://github.com/Joystream/founding-members/blob/main/RULES.md"
-        text="Read the full program rules"
-      />
-    </div>
-  </>
-);
+    </>
+  );
+};
 
 export default Metrics;

--- a/src/pages/founding-members/leaderboards/index.js
+++ b/src/pages/founding-members/leaderboards/index.js
@@ -7,6 +7,9 @@ import useAxios from '../../../utils/useAxios';
 import calculateTokensAllocated from '../../../utils/calculateTokensAllocated';
 import { ReactComponent as Achieved } from '../../../assets/svg/achieved.svg';
 import { foundingMembersJson } from '../../../data/pages/founding-members';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { types } from '@joystream/types';
+import { JoystreamWSProvider } from '../../../data/pages/founding-members';
 
 import './style.scss';
 
@@ -36,7 +39,7 @@ const PeriodHighlightFounding = ({ userData, partialTokenAllocation }) => {
             <img
               className="FoundingMembersLeaderboards__table__main__placeholder"
               src={inducted?.avatar}
-              alt="icon of founding member"
+              alt=""
               onError={e => {
                 setImageHasError(true);
               }}
@@ -72,26 +75,42 @@ const PeriodHighlightFounding = ({ userData, partialTokenAllocation }) => {
   );
 };
 
-const PeriodHighlightNonFounding = ({ userData }) => {
-  const { inducted, memberHandle, memberId, totalDirectScore, totalReferralScore, totalScore } = userData;
+const PeriodHighlightNonFounding = ({ userData , Api }) => {
+  const { memberHandle, memberId, totalDirectScore, totalReferralScore, totalScore } = userData;
+  const [imageIsReady, setImageIsReady] = useState(false);
+  const [image, setImage] = useState();
 
-  const [imageHasError, setImageHasError] = useState(false);
+  useEffect(() => {
+    async function getImage() {
+      if(memberId && Api) {
+        setImage((await Api.query.members.membershipById(memberId)).avatar_uri);
+      }
+    }
+    getImage();
+  }, [Api]);
+
+  useEffect(() => {
+    if(image) {
+      const img = new Image();
+      img.addEventListener('load',() => {
+        setImageIsReady(true);
+      });
+      img.src = image;
+    }
+  }, [image]);
 
   return (
     <>
       <div className="FoundingMembersLeaderboards__table__main">
-        {!imageHasError && inducted?.avatar ? (
+        {imageIsReady ? (
           <img
             className="FoundingMembersLeaderboards__table__main__placeholder"
-            src={inducted?.avatar}
-            alt="icon of founding member"
-            onError={e => {
-              setImageHasError(true);
-            }}
+            src={image}
+            alt=""
           />
-        ) : (
-          <div className="FoundingMembersLeaderboards__table__main__placeholder"></div>
-        )}
+         ) : (
+           <div className="FoundingMembersLeaderboards__table__main__placeholder"></div>
+         )}
         <div className="FoundingMembersLeaderboards__table__main__data">
           <p className="FoundingMembersLeaderboards__table__main__name">@{memberHandle}</p>
           <p className="FoundingMembersLeaderboards__table__main__handle">Member: #{memberId}</p>
@@ -114,6 +133,17 @@ const Leaderboards = ({ location }) => {
   const [isFounding, setIsFounding] = useState(location?.state?.isFoundingMember !== false);
   const [response, loading, error] = useAxios(foundingMembersJson);
   const [partialTokenAllocation, setPartialTokenAllocation] = useState();
+  const [Api, setApi] = useState();
+
+  useEffect(() => {
+    async function setUpApi() {
+      const provider = new WsProvider(JoystreamWSProvider);
+      const api = await ApiPromise.create({ provider, types });
+      await api.isReady;
+      setApi(api);
+    }
+    setUpApi();
+  }, []);
 
   useEffect(() => {
     if (response) {
@@ -153,7 +183,7 @@ const Leaderboards = ({ location }) => {
             key={index}
             className="FoundingMembersLeaderboards__table__row FoundingMembersLeaderboards__table__row--nonfounding"
           >
-            <PeriodHighlightNonFounding key={index} userData={foundingMember} />
+            <PeriodHighlightNonFounding key={index} userData={foundingMember} Api={Api}/>
           </Table.Row>
         ));
     }


### PR DESCRIPTION
This PR aims to implement Non-FM Avatar loading (Ref: https://github.com/Joystream/joystream-org/issues/289)

Initially I had implemented the link being immediately set as the src  and then if there is an error it would switch to the gray placeholder. But this way, there is a 0.2-0.5 sec period where it would show the broken image icon when the link didn't work. This didn't look the prettiest so I switched my approach. Now, every component preloads the icon and only if it is properly loaded would it be set as the icon.

Now, I'm not so sure if my laptop/internet is at fault here but when this starts loading I get some lag occasionally. I would love it if the reviewer(s) could see if it also the case. If it is, we can try to go back to the previous solution or figure something else out. 