### PR TITLE
Quick Website Changes

### DIFF
--- a/__tests__/pages/__snapshots__/index.test.js.snap
+++ b/__tests__/pages/__snapshots__/index.test.js.snap
@@ -15,7 +15,6 @@ exports[`IndexPage page renders correctly 1`] = `
   <BecomeFoundingMember />
   <WhatWeDo />
   <WhyYouShouldJoin />
-  <ExploreJoystream />
   <RoadToMainnet />
   <EarnTokens />
 </BaseLayout>

--- a/src/components/Banner/style.scss
+++ b/src/components/Banner/style.scss
@@ -28,7 +28,7 @@
     }
 
     &:focus {
-        text-decoration: underline;
+      text-decoration: underline;
     }
   }
 }

--- a/src/components/Footer/data.js
+++ b/src/components/Footer/data.js
@@ -1,6 +1,5 @@
 import { ReactComponent as TwitterIcon } from '../../assets/svg/twitter.svg';
 import { ReactComponent as GithubIcon } from '../../assets/svg/github.svg';
-import { ReactComponent as TelegramIcon } from '../../assets/svg/telegram.svg';
 import { ReactComponent as DiscordIcon } from '../../assets/svg/discord.svg';
 import { sharedData } from '../../data/pages';
 
@@ -28,7 +27,6 @@ const usefulLinks = [
 const socialMedias = [
   { icon: TwitterIcon, href: sharedData.social.twitterLink, name: 'Twitter' },
   { icon: GithubIcon, href: sharedData.links.github, name: 'GitHub' },
-  { icon: TelegramIcon, href: sharedData.social.telegramLink, name: 'Telegram' },
   { icon: DiscordIcon, href: sharedData.social.discordLink, name: 'Discord' }
 ];
 

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -35,7 +35,7 @@ const Footer = () => {
         <p className="Footer__form__subtitle">Don't worry about spam! Keep track of all important updates</p>
         <form
           method="post"
-          action="http://joystream.us11.list-manage.com/subscribe/post?u=932de577aec9616d4516b4e0f&amp;id=459ba8d1da"
+          action="https://joystream.us11.list-manage.com/subscribe/post?u=932de577aec9616d4516b4e0f&amp;id=459ba8d1da"
           name="mc-embedded-subscribe-form"
           target="_blank"
           noValidate
@@ -57,7 +57,7 @@ const Footer = () => {
       </div>
       <h2 className="Footer__header">Get notified</h2>
       <Button
-        href="http://joystream.us11.list-manage.com/subscribe/post?u=932de577aec9616d4516b4e0f&amp;id=459ba8d1da"
+        href="https://joystream.us11.list-manage.com/subscribe/post?u=932de577aec9616d4516b4e0f&amp;id=459ba8d1da"
         secondary
         className="Footer__button"
       >


### PR DESCRIPTION
- Removed Telegram from Footer.
- Moved links in Footer form from `http` to `https` to fix the `This form is not secure. Auto-fill has been turned off` warning. (ref. https://github.com/Joystream/joystream-org/issues/290)