### PR TITLE
FM Changes

### DIFF
--- a/src/pages/founding-members/components/List/index.js
+++ b/src/pages/founding-members/components/List/index.js
@@ -46,7 +46,7 @@ const List = ({ className, data, type }) => (
   <div className={`${className} FoundingMembersPage__list-wrapper`}>
     <div className="FoundingMembersPage__list">
       <h2 className="FoundingMembersPage__list__title">
-        {type === 'current' ? 'Current' : 'New'} founding members <span>{data?.length}</span>
+        {type === 'current' ? 'Current' : 'New'} founding members<span>{data?.length}</span>
       </h2>
       <div className="FoundingMembersPage__cards">
         {data?.map((founderData, index) => (

--- a/src/pages/founding-members/components/List/index.js
+++ b/src/pages/founding-members/components/List/index.js
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import CardCarousel from '../../../../components/CardCarousel';
-import calculateTokensAllocated from '../../../../utils/calculateTokensAllocated';
+import formatDate from '../../../../utils/formatDate';
 
 import './style.scss';
 
-const Card = ({ founderData, partialTokenAllocation }) => {
+const Card = ({ founderData }) => {
   const [imageHasError, setImageHasError] = useState(false);
 
   return (
@@ -32,9 +32,9 @@ const Card = ({ founderData, partialTokenAllocation }) => {
           <p className="FoundingMembersPage__card__score__stat">{founderData?.totalScore}</p>
         </div>
         <div className="FoundingMembersPage__card__score">
-          <p className="FoundingMembersPage__card__score__title">Tokens allocated / projected</p>
+          <p className="FoundingMembersPage__card__score__title">Induction Date</p>
           <p className="FoundingMembersPage__card__score__stat">
-            {calculateTokensAllocated(founderData?.extraAllocation, founderData?.totalScore, partialTokenAllocation)}
+            {founderData?.inducted?.inductedDate ? formatDate(founderData?.inducted?.inductedDate) : '-'}
           </p>
         </div>
       </div>
@@ -42,17 +42,17 @@ const Card = ({ founderData, partialTokenAllocation }) => {
   );
 };
 
-const List = ({ className, data, type, partialTokenAllocation }) => (
+const List = ({ className, data, type }) => (
   <div className={`${className} FoundingMembersPage__list-wrapper`}>
     <div className="FoundingMembersPage__list">
       <h2 className="FoundingMembersPage__list__title">
         {type === 'current' ? 'Current' : 'New'} founding members <span>{data?.length}</span>
       </h2>
-      <CardCarousel>
+      <div className="FoundingMembersPage__cards">
         {data?.map((founderData, index) => (
-          <Card founderData={founderData} key={index} partialTokenAllocation={partialTokenAllocation} />
+          <Card founderData={founderData} key={index} />
         ))}
-      </CardCarousel>
+      </div>
     </div>
   </div>
 );

--- a/src/pages/founding-members/components/List/style.scss
+++ b/src/pages/founding-members/components/List/style.scss
@@ -6,11 +6,11 @@
   }
 
   &__list {
-    width: 1242px;
-    margin: 0 auto;
+    @extend %container;
+
+    padding: 0 10px 0 10px;
 
     &__title {
-      margin: 0 0 40px 0;
       font-family: $font-primary;
       font-size: 40px;
       line-height: 48px;
@@ -26,11 +26,10 @@
   &__cards {
     display: grid;
     width: 100%;
+    margin-top: 40px;
     overflow: hidden;
     gap: 15px;
-    grid-auto-columns: 288px;
-    grid-auto-flow: column;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: repeat(4, 288px);
   }
 
   &__card {
@@ -98,12 +97,21 @@
 
   @media (max-width: 1300px) {
     &__list {
-      width: 100%;
-      margin: 0;
-
       &__title {
-        padding-left: 40px;
+        padding: 0 40px 0 40px;
       }
+    }
+
+    &__cards {
+      justify-content: unset;
+      padding: 0 40px 0 40px;
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  @media (max-width: 900px) {
+    &__cards {
+      grid-template-columns: repeat(2, 1fr);
     }
   }
 
@@ -113,6 +121,12 @@
         font-size: 32px;
         line-height: 40px;
       }
+    }
+  }
+
+  @media (max-width: 650px) {
+    &__cards {
+      grid-template-columns: 1fr;
     }
   }
 }

--- a/src/pages/founding-members/components/List/style.scss
+++ b/src/pages/founding-members/components/List/style.scss
@@ -23,12 +23,20 @@
     }
   }
 
+  &__cards {
+    display: grid;
+    width: 100%;
+    overflow: hidden;
+    gap: 15px;
+    grid-auto-columns: 288px;
+    grid-auto-flow: column;
+    grid-template-rows: 1fr 1fr;
+  }
+
   &__card {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    min-width: 288px;
-    min-height: 245px;
     padding: 24px;
     background-color: white;
 
@@ -67,7 +75,7 @@
     &__scores {
       display: flex;
       justify-content: space-between;
-      margin: 11px 0 19px 0;
+      margin: 11px 0 0 0;
     }
 
     &__score {

--- a/src/pages/founding-members/components/Metrics/index.js
+++ b/src/pages/founding-members/components/Metrics/index.js
@@ -1,12 +1,14 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Table from '../../../../components/Table';
 import { ArrowButton } from '../../index';
 import { ReactComponent as Achieved } from '../../../../assets/svg/achieved.svg';
-import { Link } from 'gatsby';
+import { ApiPromise, WsProvider } from '@polkadot/api';
+import { types } from '@joystream/types';
+import { JoystreamWSProvider } from '../../../../data/pages/founding-members';
 
 import './style.scss';
 
-const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
+const MetricsRowFoundingData = ({ data }) => {
   const [imageHasError, setImageHasError] = useState(false);
 
   return (
@@ -17,16 +19,14 @@ const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
             <img
               className="FoundingMembersPage__leaderboard__main__placeholder"
               src={data?.inducted?.avatar}
-              alt="icon of founding member"
+              alt=""
               onError={() => {
                 setImageHasError(true);
               }}
             />
-            {founding && (
-              <div className="FoundingMembersPage__leaderboard__main__checkmark">
-                <Achieved />
-              </div>
-            )}
+            <div className="FoundingMembersPage__leaderboard__main__checkmark">
+              <Achieved />
+            </div>
           </>
         ) : (
           <div className="FoundingMembersPage__leaderboard__main__placeholder"></div>
@@ -42,94 +42,147 @@ const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
   );
 };
 
-const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, partialTokenAllocation }) => (
-  <>
-    <div className="FoundingMembersPage__metrics">
-      <h2 className="FoundingMembersPage__metrics__title">Key metrics for the program</h2>
-      <div className="FoundingMembersPage__metrics__list">
-        <div>
-          <p className="FoundingMembersPage__metrics__stat">{sizeOfFirstTokenPool && `${sizeOfFirstTokenPool}%`}</p>
-          <p className="FoundingMembersPage__metrics__text">size of initial token pool</p>
-        </div>
-        <div>
-          <p className="FoundingMembersPage__metrics__stat">{foundingMembers?.length}</p>
-          <p className="FoundingMembersPage__metrics__text">number of founding members</p>
-        </div>
-        <div>
-          <p className="FoundingMembersPage__metrics__stat">
-            {nonFoundingMembers && nonFoundingMembers.filter(member => member.totalDirectScore > 0).length}
-          </p>
-          <p className="FoundingMembersPage__metrics__text">number of founding member candidates</p>
+const MetricsRowNonFoundingData = ({ data, Api }) => {
+  const [image, setImage] = useState();
+  const [imageIsReady, setImageIsReady] = useState(false);
+
+  useEffect(() => {
+    async function getImage() {
+      if (data?.memberId && Api) {
+        setImage((await Api.query.members.membershipById(data?.memberId)).avatar_uri);
+      }
+    }
+    getImage();
+  }, [Api]);
+
+  useEffect(() => {
+    if (image) {
+      const img = new Image();
+      img.addEventListener('load', () => {
+        setImageIsReady(true);
+      });
+      img.src = image;
+    }
+  }, [image]);
+
+  return (
+    <>
+      <div className="FoundingMembersPage__leaderboard__main">
+        {imageIsReady ? (
+          <>
+            <img className="FoundingMembersPage__leaderboard__main__placeholder" src={image} alt="" />
+          </>
+        ) : (
+          <div className="FoundingMembersPage__leaderboard__main__placeholder"></div>
+        )}
+        <div className="FoundingMembersPage__leaderboard__main__data">
+          <p className="FoundingMembersPage__leaderboard__main__name">@{data?.memberHandle}</p>
         </div>
       </div>
-    </div>
-    <div className="FoundingMembersPage__leaderboards">
-      <div className="FoundingMembersPage__leaderboard-left">
-        <h3 className="FoundingMembersPage__leaderboards__title">Leaderboards</h3>
+      <div className="FoundingMembersPage__leaderboard__score">
+        <p>{data?.totalScore}</p>
+      </div>
+    </>
+  );
+};
+
+const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, partialTokenAllocation }) => {
+  const [Api, setApi] = useState();
+
+  useEffect(() => {
+    async function setUpApi() {
+      const provider = new WsProvider(JoystreamWSProvider);
+      const api = await ApiPromise.create({ provider, types });
+      await api.isReady;
+      setApi(api);
+    }
+    setUpApi();
+  }, []);
+
+  return (
+    <>
+      <div className="FoundingMembersPage__metrics">
+        <h2 className="FoundingMembersPage__metrics__title">Key metrics for the program</h2>
+        <div className="FoundingMembersPage__metrics__list">
+          <div>
+            <p className="FoundingMembersPage__metrics__stat">{sizeOfFirstTokenPool && `${sizeOfFirstTokenPool}%`}</p>
+            <p className="FoundingMembersPage__metrics__text">size of initial token pool</p>
+          </div>
+          <div>
+            <p className="FoundingMembersPage__metrics__stat">{foundingMembers?.length}</p>
+            <p className="FoundingMembersPage__metrics__text">number of founding members</p>
+          </div>
+          <div>
+            <p className="FoundingMembersPage__metrics__stat">
+              {nonFoundingMembers && nonFoundingMembers.filter(member => member.totalDirectScore > 0).length}
+            </p>
+            <p className="FoundingMembersPage__metrics__text">number of founding member candidates</p>
+          </div>
+        </div>
+      </div>
+      <div className="FoundingMembersPage__leaderboards">
+        <div className="FoundingMembersPage__leaderboard-left">
+          <h3 className="FoundingMembersPage__leaderboards__title">Leaderboards</h3>
+          <div className="FoundingMembersPage__leaderboard-wrapper">
+            <h4 className="FoundingMembersPage__leaderboard__title">Founding Members</h4>
+            <Table className="FoundingMembersPage__leaderboard">
+              <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--founding">
+                <Table.HeaderItem></Table.HeaderItem>
+                <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
+              </Table.Header>
+              <Table.Body className="FoundingMembersPage__leaderboard__body">
+                {foundingMembers
+                  ?.sort((prev, next) => next.totalScore - prev.totalScore)
+                  ?.map((foundingMember, index) => (
+                    <Table.Row
+                      key={index}
+                      className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--founding"
+                    >
+                      <MetricsRowFoundingData key={index} data={foundingMember} />
+                    </Table.Row>
+                  ))}
+              </Table.Body>
+            </Table>
+            <ArrowButton
+              className="FoundingMembersPage__leaderboard__button"
+              link="/founding-members/leaderboards"
+              text="All Founding Member Scores"
+            />
+          </div>
+        </div>
         <div className="FoundingMembersPage__leaderboard-wrapper">
-          <h4 className="FoundingMembersPage__leaderboard__title">Founding Members</h4>
+          <h4 className="FoundingMembersPage__leaderboard__title">Non-Founding Members</h4>
           <Table className="FoundingMembersPage__leaderboard">
-            <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--founding">
+            <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--nonfounding">
               <Table.HeaderItem></Table.HeaderItem>
               <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
             </Table.Header>
             <Table.Body className="FoundingMembersPage__leaderboard__body">
-              {foundingMembers
-                ?.sort((prev, next) => next.totalScore - prev.totalScore)
-                ?.map((foundingMember, index) => (
-                  <Table.Row
-                    key={index}
-                    className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--founding"
-                  >
-                    <MetricsRowData
-                      key={index}
-                      data={foundingMember}
-                      partialTokenAllocation={partialTokenAllocation}
-                      founding
-                    />
-                  </Table.Row>
-                ))}
+              {nonFoundingMembers?.map((nonFoundingMember, index) => (
+                <Table.Row
+                  key={index}
+                  className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--nonfounding"
+                >
+                  <MetricsRowNonFoundingData key={index} data={nonFoundingMember} Api={Api} />
+                </Table.Row>
+              ))}
             </Table.Body>
           </Table>
           <ArrowButton
             className="FoundingMembersPage__leaderboard__button"
-            link="/founding-members/leaderboards"
-            text="All Founding Member Scores"
+            to="/founding-members/leaderboards"
+            text="All Regular Member Scores"
+            state={{ isFoundingMember: false }}
           />
         </div>
-      </div>
-      <div className="FoundingMembersPage__leaderboard-wrapper">
-        <h4 className="FoundingMembersPage__leaderboard__title">Non-Founding Members</h4>
-        <Table className="FoundingMembersPage__leaderboard">
-          <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--nonfounding">
-            <Table.HeaderItem></Table.HeaderItem>
-            <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
-          </Table.Header>
-          <Table.Body className="FoundingMembersPage__leaderboard__body">
-            {nonFoundingMembers?.map((foundingMember, index) => (
-              <Table.Row
-                key={index}
-                className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--nonfounding"
-              >
-                <MetricsRowData key={index} data={foundingMember} />
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
         <ArrowButton
-          className="FoundingMembersPage__leaderboard__button"
-          to="/founding-members/leaderboards"
-          text="All Regular Member Scores"
-          state={{ isFoundingMember: false }}
+          className="FoundingMembersPage__leaderboards__button"
+          link="https://github.com/Joystream/founding-members/blob/main/RULES.md"
+          text="Read the full program rules"
         />
       </div>
-      <ArrowButton
-        className="FoundingMembersPage__leaderboards__button"
-        link="https://github.com/Joystream/founding-members/blob/main/RULES.md"
-        text="Read the full program rules"
-      />
-    </div>
-  </>
-);
+    </>
+  );
+};
 
 export default Metrics;

--- a/src/pages/founding-members/components/Metrics/index.js
+++ b/src/pages/founding-members/components/Metrics/index.js
@@ -86,7 +86,7 @@ const MetricsRowNonFoundingData = ({ data, Api }) => {
   );
 };
 
-const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, partialTokenAllocation }) => {
+const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool }) => {
   const [Api, setApi] = useState();
 
   useEffect(() => {

--- a/src/pages/founding-members/components/Metrics/index.js
+++ b/src/pages/founding-members/components/Metrics/index.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import Table from '../../../../components/Table';
 import { ArrowButton } from '../../index';
 import { ReactComponent as Achieved } from '../../../../assets/svg/achieved.svg';
-import calculateTokensAllocated from '../../../../utils/calculateTokensAllocated';
 import { Link } from 'gatsby';
 
 import './style.scss';
@@ -36,13 +35,6 @@ const MetricsRowData = ({ data, founding, partialTokenAllocation }) => {
           <p className="FoundingMembersPage__leaderboard__main__name">@{data?.memberHandle}</p>
         </div>
       </div>
-      {founding && (
-        <div style={{ justifySelf: 'center' }} className="FoundingMembersPage__leaderboard__score">
-          <p>
-            {calculateTokensAllocated(data?.extraAllocation, data?.totalScore, partialTokenAllocation)}
-          </p>
-        </div>
-      )}
       <div className="FoundingMembersPage__leaderboard__score">
         <p>{data?.totalScore}</p>
       </div>
@@ -59,10 +51,6 @@ const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, pa
           <p className="FoundingMembersPage__metrics__stat">{sizeOfFirstTokenPool && `${sizeOfFirstTokenPool}%`}</p>
           <p className="FoundingMembersPage__metrics__text">size of initial token pool</p>
         </div>
-        {/* <div>
-          <p className="FoundingMembersPage__metrics__stat">71%</p>
-          <p className="FoundingMembersPage__metrics__text">size of second token pool</p>
-        </div> */}
         <div>
           <p className="FoundingMembersPage__metrics__stat">{foundingMembers?.length}</p>
           <p className="FoundingMembersPage__metrics__text">number of founding members</p>
@@ -83,7 +71,6 @@ const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, pa
           <Table className="FoundingMembersPage__leaderboard">
             <Table.Header className="FoundingMembersPage__leaderboard__header FoundingMembersPage__leaderboard__header--founding">
               <Table.HeaderItem></Table.HeaderItem>
-              <Table.HeaderItem textAlign="center">Tokens allocated / projected</Table.HeaderItem>
               <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
             </Table.Header>
             <Table.Body className="FoundingMembersPage__leaderboard__body">

--- a/src/pages/founding-members/components/Metrics/index.js
+++ b/src/pages/founding-members/components/Metrics/index.js
@@ -74,19 +74,21 @@ const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, pa
               <Table.HeaderItem textAlign="right">Total score</Table.HeaderItem>
             </Table.Header>
             <Table.Body className="FoundingMembersPage__leaderboard__body">
-              {foundingMembers?.map((foundingMember, index) => (
-                <Table.Row
-                  key={index}
-                  className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--founding"
-                >
-                  <MetricsRowData
+              {foundingMembers
+                ?.sort((prev, next) => next.totalScore - prev.totalScore)
+                ?.map((foundingMember, index) => (
+                  <Table.Row
                     key={index}
-                    data={foundingMember}
-                    partialTokenAllocation={partialTokenAllocation}
-                    founding
-                  />
-                </Table.Row>
-              ))}
+                    className="FoundingMembersPage__leaderboard__row FoundingMembersPage__leaderboard__row--founding"
+                  >
+                    <MetricsRowData
+                      key={index}
+                      data={foundingMember}
+                      partialTokenAllocation={partialTokenAllocation}
+                      founding
+                    />
+                  </Table.Row>
+                ))}
             </Table.Body>
           </Table>
           <ArrowButton

--- a/src/pages/founding-members/components/Metrics/style.scss
+++ b/src/pages/founding-members/components/Metrics/style.scss
@@ -97,7 +97,7 @@
       height: 40px;
 
       &--founding {
-        grid-template-columns: 1.4fr 1.2fr .9fr;
+        grid-template-columns: 1.5fr 1fr;
       }
 
       &--nonfounding {
@@ -114,7 +114,7 @@
       background-color: white;
 
       &--founding {
-        grid-template-columns: 1.4fr 1.2fr .9fr;
+        grid-template-columns: 1.5fr 1fr;
       }
 
       &--nonfounding {
@@ -235,19 +235,11 @@
     &__leaderboard {
       &__header--founding {
         grid-template-columns: 2.5fr 1fr;
-
-        & > p:nth-of-type(2) {
-          display: none;
-        }
       }
 
       &__row {
         &--founding {
           grid-template-columns: 2.5fr 1fr;
-
-          & > div:nth-of-type(2) {
-            display: none;
-          }
         }
       }
     }

--- a/src/pages/founding-members/index.js
+++ b/src/pages/founding-members/index.js
@@ -52,7 +52,6 @@ const FoundingMembersPage = () => {
   const [formerDate, setFormerDate] = useState();
   const [latterDate, setLatterData] = useState();
   const [newFoundingMembers, setNewFoundingMembers] = useState([]);
-  const [partialTokenAllocation, setPartialTokenAllocation] = useState();
 
   useEffect(() => {
     if (response) {
@@ -66,20 +65,6 @@ const FoundingMembersPage = () => {
       );
 
       setNewFoundingMembers(newFoundingMembers);
-    }
-  }, [response]);
-
-  useEffect(() => {
-    if (response) {
-      let partialTokenAllocation = 0;
-      const totalScoreSum = response?.currentFoundingMembers?.reduce((prev, curr) => prev + curr?.totalScore, 0);
-
-      if (totalScoreSum) {
-        partialTokenAllocation =
-          (response?.poolStats?.currentPoolSize - response?.poolStats?.allocatedFromPool) / totalScoreSum;
-      }
-
-      setPartialTokenAllocation(partialTokenAllocation);
     }
   }, [response]);
 
@@ -128,7 +113,6 @@ const FoundingMembersPage = () => {
           className="FoundingMembersPage__list-wrapper--new"
           type="new"
           data={newFoundingMembers}
-          partialTokenAllocation={partialTokenAllocation}
         />
       ) : null}
       <Benefits newMembers={newFoundingMembers?.length} />
@@ -136,13 +120,11 @@ const FoundingMembersPage = () => {
         className="FoundingMembersPage__list-wrapper--current"
         type="current"
         data={response?.currentFoundingMembers}
-        partialTokenAllocation={partialTokenAllocation}
       />
       <Metrics
         foundingMembers={response?.currentFoundingMembers}
         nonFoundingMembers={response?.scores?.totalScores?.filter(({ inducted }) => !inducted)}
         sizeOfFirstTokenPool={response?.poolStats?.currentPoolSize}
-        partialTokenAllocation={partialTokenAllocation}
       />
       <div className="FoundingMembersPage__cta-wrapper">
         <div className="FoundingMembersPage__cta">

--- a/src/pages/founding-members/leaderboards/index.js
+++ b/src/pages/founding-members/leaderboards/index.js
@@ -63,9 +63,6 @@ const PeriodHighlightFounding = ({ userData, partialTokenAllocation }) => {
         <p>{totalScore}</p>
       </div>
       <div className="FoundingMembersLeaderboards__table__score">
-        <p>{calculateTokensAllocated(extraAllocation, totalScore, partialTokenAllocation)}</p>
-      </div>
-      <div className="FoundingMembersLeaderboards__table__score">
         <p>{formattedDate}</p>
       </div>
     </>
@@ -207,7 +204,6 @@ const Leaderboards = ({ location }) => {
             <p className="FoundingMembersLeaderboards__table__header__item">Total Score</p>
             {isFounding && (
               <>
-                <p className="FoundingMembersLeaderboards__table__header__item">Tokens Allocated / Projected</p>
                 <p className="FoundingMembersLeaderboards__table__header__item">Inducted</p>
               </>
             )}

--- a/src/pages/founding-members/leaderboards/index.js
+++ b/src/pages/founding-members/leaderboards/index.js
@@ -12,10 +12,9 @@ import { JoystreamWSProvider } from '../../../data/pages/founding-members';
 
 import './style.scss';
 
-const PeriodHighlightFounding = ({ userData, partialTokenAllocation }) => {
+const PeriodHighlightFounding = ({ userData }) => {
   const {
     inducted,
-    extraAllocation,
     memberHandle,
     memberId,
     totalDirectScore,
@@ -124,7 +123,6 @@ const PeriodHighlightNonFounding = ({ userData, Api }) => {
 const Leaderboards = ({ location }) => {
   const [isFounding, setIsFounding] = useState(location?.state?.isFoundingMember !== false);
   const [response, loading, error] = useAxios(foundingMembersJson);
-  const [partialTokenAllocation, setPartialTokenAllocation] = useState();
   const [Api, setApi] = useState();
 
   useEffect(() => {
@@ -136,20 +134,6 @@ const Leaderboards = ({ location }) => {
     }
     setUpApi();
   }, []);
-
-  useEffect(() => {
-    if (response) {
-      let partialTokenAllocation = 0;
-      const totalScoreSum = response?.currentFoundingMembers?.reduce((prev, curr) => prev + curr?.totalScore, 0);
-
-      if (totalScoreSum) {
-        partialTokenAllocation =
-          (response?.poolStats?.currentPoolSize - response?.poolStats?.allocatedFromPool) / totalScoreSum;
-      }
-
-      setPartialTokenAllocation(partialTokenAllocation);
-    }
-  }, [response]);
 
   const renderBody = () => {
     if (isFounding) {
@@ -163,7 +147,6 @@ const Leaderboards = ({ location }) => {
             <PeriodHighlightFounding
               key={index}
               userData={foundingMember}
-              partialTokenAllocation={partialTokenAllocation}
             />
           </Table.Row>
         ));

--- a/src/pages/founding-members/leaderboards/style.scss
+++ b/src/pages/founding-members/leaderboards/style.scss
@@ -86,7 +86,7 @@
       padding: 0 0 0 30px;
 
       &--founding {
-        grid-template-columns: 1.8fr .8fr .8fr .8fr 1.4fr 1fr;
+        grid-template-columns: 2.5fr 1fr 1fr 1fr 1fr;
       }
 
       &--nonfounding {
@@ -108,7 +108,7 @@
       background-color: white;
 
       &--founding {
-        grid-template-columns: 1.8fr .8fr .8fr .8fr 1.4fr 1fr;
+        grid-template-columns: 2.5fr 1fr 1fr 1fr 1fr;
       }
 
       &--nonfounding {
@@ -236,7 +236,7 @@
 
     &__table {
       &__header--founding {
-        grid-template-columns: 1.6fr .8fr .8fr .8fr 1.5fr;
+        grid-template-columns: 1.6fr .8fr .8fr .8fr .8fr;
 
         p:nth-of-type(6) {
           display: none;
@@ -244,7 +244,7 @@
       }
 
       &__row--founding {
-        grid-template-columns: 1.6fr .8fr .8fr .8fr 1.5fr;
+        grid-template-columns: 1.6fr .8fr .8fr .8fr .8fr;
 
         div:nth-of-type(6) {
           display: none;


### PR DESCRIPTION
Changes:
- Removed allocated/projected from: Current Founding Members Carousel, FM Key Metrics, FM Leaderboards
- Changed Current FM Carousel to have two rows, no more scroll
- Make Carousel Cards smaller to adapt to changes made before (reference issue: https://github.com/Joystream/joystream-org/issues/306)
- Implement sorting on Metrics FM leaderboard
- Implement non-founding member image loading on Metrics and Leaderboards (reference issue: https://github.com/Joystream/joystream-org/issues/289)

This is how the "Carousel" will look with more members:

![with-more-fm](https://user-images.githubusercontent.com/26174828/114555979-882b4100-9c68-11eb-92b5-209921b6699b.png)

I don't remember if this was intentional or my oversight but the margin disappears on the left side eventually. Is this something we want or should I add it?

*+* I also added induction date instead of allocated/projected as placeholder.