### PR TITLE
Fix stylelint not working on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "scripts": {
     "lint": "eslint --ignore-path .gitignore . --ext js --ext jsx",
     "lint:fix": "yarn lint --fix",
-    "stylelint": "stylelint 'src/**/*.scss'",
+    "stylelint": "stylelint \"src/**/*.scss\"",
     "build": "gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",


### PR DESCRIPTION
This PR aims to fix the problem explained in this issue: https://github.com/Joystream/joystream-org/issues/222

Although the proposed solution I assume does work on windows, it doesn't work on linux. The solution should be just to add escaped double quotes instead of the currently implemented single quotes.

Update: Tested on both Ubuntu 20.04 and Windows and it seems to work perfectly now! 