### PR TITLE
Leaderboard relevance data

### DIFF
--- a/src/pages/founding-members/leaderboards/index.js
+++ b/src/pages/founding-members/leaderboards/index.js
@@ -19,15 +19,18 @@ import { foundingMembersJson } from '../../../data/pages/founding-members';
 import useAxios from '../../../utils/useAxios';
 import './style.scss';
 
+const formatDate = date =>
+  `${date.getDate()}.${date.getMonth() + 1}.${date
+    .getFullYear()
+    .toString()
+    .substr(-2)}`;
+
 const PeriodHighlightFounding = ({ userData, t }) => {
   const { inducted, memberHandle, memberId, totalDirectScore, totalReferralScore, totalScore } = userData;
 
   const [imageHasError, setImageHasError] = useState(false);
   const userDate = new Date(inducted.inductedDate);
-  const formattedDate = `${userDate.getDate()}.${userDate.getMonth() + 1}.${userDate
-    .getFullYear()
-    .toString()
-    .substr(-2)}`;
+  const formattedDate = formatDate(userDate);
 
   return (
     <>
@@ -205,6 +208,13 @@ const Leaderboards = ({ location }) => {
               </div>
             </div>
           </div>
+          {response?.scores?.cutoff ? (
+            <div className="FoundingMembersLeaderboards__scoring-cutoff-date">
+              <p className="FoundingMembersLeaderboards__scoring-cutoff-date__text">
+                From data processed before: {formatDate(new Date(response?.scores?.cutoff))}
+              </p>
+            </div>
+          ) : null}
         </div>
 
         <Table className="FoundingMembersLeaderboards__table">

--- a/src/pages/founding-members/leaderboards/style.scss
+++ b/src/pages/founding-members/leaderboards/style.scss
@@ -76,6 +76,24 @@
     }
   }
 
+  &__scoring-cutoff-date {
+    @extend %container;
+
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    flex-direction: row-reverse;
+    height: 20px;
+
+    &__text {
+      position: absolute;
+      bottom: -30px;
+      font-family: $font-secondary;
+      font-size: 14px;
+      color: white;
+    }
+  }
+
   &__table {
     @extend %container;
 
@@ -231,6 +249,15 @@
 
       &__title {
         margin-bottom: 18px;
+      }
+    }
+
+    &__scoring-cutoff-date {
+      margin-right: 32px;
+      padding: 0;
+
+      &__text {
+        font-size: 12px;
       }
     }
 


### PR DESCRIPTION
This PR aims to implement the ability for a user to understand how relevant and up to date the data from the leaderboard really is. The explanation of the issue can be found here: https://github.com/Joystream/joystream-org/issues/327

Changes:
- Add cutoff date to the fm data (https://github.com/Joystream/founding-members/pull/50)
- Add and implement the date above the leaderboards