### PR TITLE
Add support for Spanish, French, Mandarin language

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,7 +59,7 @@ module.exports = {
       resolve: `gatsby-plugin-react-i18next`,
       options: {
         localeJsonSourceName: `locale`, // name given to `gatsby-source-filesystem` plugin.
-        languages: [`en`, `ru`],
+        languages: [`en`, `ru`, 'zh', 'es', 'fr'],
         defaultLanguage: `en`,
         siteUrl: `https://www.joystream.org/`,
         i18nextOptions: {
@@ -71,7 +71,7 @@ module.exports = {
         pages: [
           {
             matchPath: '/',
-            languages: ['en','ru']
+            languages: ['en','ru', 'zh', 'es', 'fr']
           }
         ]
       }

--- a/src/locales/es/about.json
+++ b/src/locales/es/about.json
@@ -1,0 +1,51 @@
+{
+  "about": {
+    "general": {
+      "roles": {
+        "blockchain": "Blockchain Engineer",
+        "frontEnd": "Front-End Engineer",
+        "design": "Designer",
+        "growth": "Growth",
+        "core": "Core",
+        "ceo": "CEO",
+        "cto": "CTO",
+        "cooAndGrowth": "COO & Growth",
+        "all": "All",
+        "allMembers": "All members"
+      }
+    },
+    "siteMetadata": {
+      "title": "About us",
+      "description": "We don't just offer great compensation and flexibility, but the perfect mission, team and timing for you to build something that changes everything."
+    },
+    "hero": {
+      "title": "We are building Joystream to set it free",
+      "subtitle": "Jsgenesis is the core team building Joystream the platform and open-source blockchain."
+    },
+    "ourTeam": {
+      "title": "Our team",
+      "subtitle": "We come from different continents, but share a passion for open source, blockchain technology, distributed systems, privacy and building a new internet based on accountable and forkable institutions.",
+      "moreMembers": "Load more team members"
+    },
+    "investors": {
+      "title": "Our investors"
+    },
+    "positions": {
+      "title": "Open positions",
+      "available": "3 jobs available",
+      "join": "Join",
+      "roles": {
+        "frontEnd": "Front-end Developer",
+        "blockchain": "Blockchain Developer",
+        "designer": "UI/UX Design Lead"
+      },
+      "location": "Oslo, Europe, Remote",
+      "employmentType": "Full time",
+      "salary": {
+        "frontEnd": "$80K-$130K",
+        "blockchain": "$100K-$140K",
+        "designer": "$100K-$140K"
+      }
+    }
+  }
+}

--- a/src/locales/es/acropolis.json
+++ b/src/locales/es/acropolis.json
@@ -1,0 +1,59 @@
+{
+  "acropolis": {
+    "siteMetadata": {
+      "description": "Explore the Acropolis testnet"
+    },
+    "hero": {
+      "title": "Acropolis Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ROME ON"
+    },
+    "modal": {
+      "title": "The Acropolis of Athens",
+      "text": "<0>Known for its great architecture, Acropolis'</0> perhaps most famous building is the Parthenon. It was built to celebrate their victory over Persian invaders, and is today seen as a symbol for democracy and western civilization."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "Read the specs of the newly implemented features of Acropolis."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "forum": {
+          "title": "Build and release an on-chain forum",
+          "text": "The final platform will have built in multiple ways of facilitating easy and secure public, and private, communication and information sharing among members. The forum is the first step allowing the platform members to communicate, share ideas and discuss."
+        },
+        "storageNode": {
+          "title": "Rebuild and release the storage node",
+          "text": "Where the old storage node had some bugs making it unable to sync between clients and required a hardcoded liaison, the new storage node is working as intended with no hierarchy or privileges."
+        },
+        "storageProviders": {
+          "title": "Ensure high uptime of storage providers",
+          "text": "Both content creators and consumers user experience depends on various metrics, but perhaps the most important is that the storage node they connect to responds to their request. Whether or not this goal is achieved depends on both the reliability of the software, a good reporting system and corrective actions from multiple parties."
+        },
+        "tranches": {
+          "title": "Build the storage node with \"tranches\"",
+          "text": "Although the content directory is currently small, at some point it's not feasible to expect all storage providers to have full replication of all the content. Tranches would allow storage providers to select a subset of the content directory, suitable to their capabilities."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Acropolis testnet"
+    },
+    "map": {
+      "title": "Acropolis of Athens",
+      "text": "<0>The Acropolis is a citadel on a hill in the heart of Athens.</0> It was also at the heart of Ancient Greece, a powerful civilization and empire. Acropolis is famous for its ancient buildings, architecture, historical significance and is one of the main tourist attractions of Athens. It is on UNESCOs list \"World Heritage Sites\".<1/><1/> We chose the name as we had to scale back our ambitions for the next testnet after some issues with the release of Athens. Thus, Acropolis can be considered a sub-release, despite including some new features not intended for Athens. <1/><1/> <2><0/> Explore previous testnet</2>"
+    }
+  }
+}

--- a/src/locales/es/alexandria.json
+++ b/src/locales/es/alexandria.json
@@ -1,0 +1,55 @@
+{
+  "alexandria": {
+    "siteMetadata": {
+      "description": "Explore the Alexandria testnet"
+    },
+    "hero": {
+      "title": "Alexandria Network",
+      "text": "The Alexandria release focuses on important technical updates which will facilitate more efficient future development.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY BABYLON ON"
+    },
+    "modal": {
+      "title": "Alexandria",
+      "text": "There are two sphinxes at the Pompey's Pillar site in Alexandria, Egypt. The sphinxes and associated column are one of Alexandria's most important ancient monuments. <0/><0/> The Alexandria sphinxes should not be confused with the more well-known Great Sphinx located at Giza, just under 200 kilometers south-east of Alexandria."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Alexandria testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Alexandria testnet.",
+      "goals": {
+        "membershipModule": {
+          "title": "Cleaning up the membership module",
+          "text": "Tackling technical debt in the membership module and making it possible to transition to using memberships as the only core actor identifier in the system in future releases."
+        },
+        "substrateVersion": {
+          "title": "Start using Substrate v2.0.0 RC4",
+          "text": "We are transitioning to a new version of Substrate in order to stay up to date with a broad range of enhancements, and to limit how far behind we allow our growing codebase to become."
+        },
+        "networkTesting": {
+          "title": "Enhancing our network testing",
+          "text": "Further maturing our network testing infrastructure to get one step closer to true end-to-end builds that secure an increasingly shorter development cycle."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Alexandria Network"
+    },
+    "map": {
+      "title": "Alexandria",
+      "text": "<0>Alexandria was founded in approximately 331 BC by Alexander the Great.</0> The city was best known for the Lighthouse of Alexandria, one of the Seven Wonders of the Ancient World, as well as its colossal Great Library.<1/><1/> Alexandria was the intellectual and cultural center of the ancient Mediterranean world for much of the Hellenistic age and late antiquity. It was at one time the largest city in the ancient world before being eventually overtaken by Rome.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/es/antioch.json
+++ b/src/locales/es/antioch.json
@@ -1,0 +1,42 @@
+{
+  "antioch": {
+    "siteMetadata": {
+      "description": "Explore the Antioch testnet"
+    },
+    "hero": {
+      "title": "Antioch Network",
+      "text": "The Antioch release seeks to patch a chain split bug which unfortunately sabotaged the previous testnet."
+    },
+    "heroCard": {
+      "title": "REPLACED BY SUMER ON"
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Antioch testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Antioch testnet.",
+      "goals": {
+        "substrateVersion": {
+          "title": "Upgrade Substrate Version",
+          "text": "<0>To patch the chain split issue encountered on Babylon we need to update the version of Substrate our network is built on from <1>v2-rc4</1> to <1>v2.0.1</1></0>"
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Antioch Network"
+    },
+    "map": {
+      "title": "Antioch",
+      "text": "<0>Antioch was an ancient Greek city on the eastern side of the Orontes River.</0> The city's position benefited its occupants greatly, particularly on account of such features as the spice trade, the Silk Road, and the Royal Road.<1/><1/>At its height it rivaled Alexandria as the chief city of the Near East. Many also consider the city to be \"the cradle of Christianity\".<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/es/athens.json
+++ b/src/locales/es/athens.json
@@ -1,0 +1,59 @@
+{
+  "athens": {
+    "siteMetadata": {
+      "description": "Explore the Athens testnet"
+    },
+    "hero": {
+      "title": "Athens Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "text": "AFTER LAUNCHING 17 / 04 / 19 <0/> THE NETWORK WAS UPGRADED TO <1>ACROPOLIS</1> ON"
+    },
+    "modal": {
+      "title": "Owl of Athena",
+      "text": "<0>In Greek mythology, a little owl (Athene noctua)</0> traditionally represents or accompanies Athena, the virgin goddess of wisdom. Because of such association, the bird — often referred to as the \"owl of Athena\" — has been used as a symbol of knowledge, wisdom, perspicacity and erudition throughout the Western world."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "No specifications was published for Athens."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "media": {
+          "title": "Enable media on the platform",
+          "text": "As a \"user governed media platform\", allowing users to upload and consume and content was a major goal for us."
+        },
+        "memberships": {
+          "title": "Introduce platform memberships",
+          "text": "Although we are building an open blockchain in the sense that users are free to send tokens as they like, the Joystream experience is about having the platform users own, operate and govern the platform. We are agnostic on exactly what parts of the platform will be reserved for members, some actions will require and extra level of screening and accountability."
+        },
+        "storageNode": {
+          "title": "Build and release the storage node",
+          "text": "Although a storage node was built and used to host and distribute the platform content, it had some bugs making it unable to sync between clients and required a hardcoded liaison."
+        },
+        "runtimeUpgrade": {
+          "title": "Upgrade the runtime through a Council vote",
+          "text": "The intention was for Jsgenesis to create a proposal for a <0>runtime upgrade</0> and have the Council vote on it. If the Council reached quorum, the consensus rules of the system would automatically get upgraded in flight. Unfortunately, the <1>Sparta network crashed</1> before we reached this stage, and had to start Athens as a new chain with a new genesis block."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Athens testnet"
+    },
+    "map": {
+      "title": "The city of Athens",
+      "text": "<0>Athens is the capital of Greece.</0> It was also at the heart of Ancient Greece, a powerful civilisation and empire. The city is still dominated by 5th-century BC landmarks, including the Acropolis, a hilltop citadel topped with ancient buildings like the colonnaded Parthenon temple. <1/><1/> We chose the name Athens as, like our previous testnets, Mesopotamia and Sparta, the ancient Athens' historical significance in the development towards modern democracy and the rule of law. <1/><1/> <2> <0/> Explore previous testnet</2>"
+    }
+  }
+}

--- a/src/locales/es/babylon.json
+++ b/src/locales/es/babylon.json
@@ -1,0 +1,55 @@
+{
+  "babylon": {
+    "siteMetadata": {
+      "description": "Explore the Babylon testnet"
+    },
+    "hero": {
+      "title": "Babylon Network",
+      "text": "The Babylon release offers improvements which greatly enhance the video publishing and consumption experience.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ANTIOCH ON"
+    },
+    "modal": {
+      "title": "Tower of Babel",
+      "text": "The Tower of Babel story is an origin myth meant to explain why the world's peoples speak different languages.<0/><0/>According to the story, a united human race in the generations following the Great Flood, speaking a single language and migrating eastward, comes to the land of Shinar. There they agree to build a city and a tower tall enough to reach heaven.<0/><0/> God, observing their city and tower, confounds their speech so that they can no longer understand each other, and scatters them around the world."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Babylon testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Babylon testnet.",
+      "goals": {
+        "atlas": {
+          "title": "Launch Atlas 0.1",
+          "text": "This will be the initial release of our content consumption client, aiming to be considerably more effective than the current Pioneer media experience."
+        },
+        "contentDirectory": {
+          "title": "Deploy a new content directory and corresponding working group",
+          "text": "We will be modifying the content directory to allow for a new data model for content, supported by new schemas. We will also make some associated improvements to the Content Curator Working Group."
+        },
+        "hydraNode": {
+          "title": "Deploy first self-hosted Joystream Hydra node only supporting content directory",
+          "text": "Further work on our Hydra framework is required in order to support the new content directory."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Babylon Network"
+    },
+    "map": {
+      "title": "Babylon",
+      "text": "<0>Babylon was the capital city of Babylonia, a kingdom in ancient Mesopotamia, almost 4000 years ago.</0> It was built along the left and right banks of the Euphrates river with steep embankments to contain the river's seasonal floods. <1/><1/> The city is considered to be of great historical and cultural importance. The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World and Babylon was also purported to be the site of the Tower of Babel.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/es/brand.json
+++ b/src/locales/es/brand.json
@@ -1,0 +1,198 @@
+{
+  "brand": {
+    "siteMetadata": {
+      "title": "Joystream Brand Guide"
+    },
+    "assets": {
+      "logo": "Logo",
+      "logoIcons": "Logo Icons",
+      "descriptiveIcons": "Descriptive Icons",
+      "illustrations": "Illustrations",
+      "systemIcons": "System Icons",
+      "typography": "Typography",
+      "blogPostCovers": "Blog Post Covers",
+      "displayTitle": {
+        "logoPack": "Logo Pack"
+      },
+      "files": "files"
+    },
+    "guides": {
+      "general": {
+        "logo": "Logo",
+        "overview": "Overview",
+        "logomark": "Logomark",
+        "construction": "Construction",
+        "useCases": "Use Cases",
+        "socialIcons": "Social Icons",
+        "forbiddenUses": "Forbidden Uses",
+        "colorPalettes": "Color Palettes",
+        "primaryColors": "Primary Colors",
+        "supportivePallet": "Supportive Pallet",
+        "secondaryPallet": "Secondary Pallet",
+        "iconography": "Iconography",
+        "descriptiveIcons": "Descriptive Icons",
+        "systemIcons": "System Icons",
+        "illustrations": "Illustrations",
+        "patterns": "Patterns",
+        "typography": "Typography",
+        "photography": "Photography",
+        "motion": "Motion",
+        "back": "Back",
+        "more": "More"
+      },
+      "logo": {
+        "experimentation": "Our brand should promote a feeling of experimentation, excitement and building something ethical and dynamic.",
+        "conceptIterations": "Before we agreed on a final logo concept we went through multiple iterations of various concepts. We explored various ideas in depth before settling on the final logo concept."
+      },
+      "logomarkConstruction": {
+        "title": "01. Logomark Construction",
+        "simplePrinciples": "In the end we came up with a logomark that combines several simple principles which translate well to the voice of the brand.",
+        "combination": "Our logomark is a combination of the letter J (to represent the name Joystream) and three parallel stripes that are a representation of streaming data and the flow of information and technology.",
+        "image": {
+          "logomarkDescription": "Logomark's exclusion zone is equal to the blue square height (marked as 5a in the diagram)."
+        }
+      },
+      "logoConstruction": {
+        "title": "02. Logo Construction",
+        "combination": "The Joystream logo is a combination of the logomark and dedicated typography that was designed to be the best link between the logomark and what Joystream stands for. It is firm and technical but shows plasticity and sense of a structure.",
+        "horizontalLockup": "Horizontal Lockup",
+        "verticalLockup": "Vertical Lockup"
+      },
+      "logoUseCases": {
+        "title": "03. Logo Use Cases",
+        "originalForm": "The Joystream logo is primarly used in its original form on white backgrounds but it can also be used in its complimentary forms if necessary. Examples show such use cases below.",
+        "safeUse": "The smallest safe use",
+        "visualPresentation": "In order to ensure the best visual presentation of the logo, it is best offered in sizes between <0>200 and 500+px</0> width on digital devices.",
+        "horizontalNarrow": "The Joystream logo should never be narrower than 100px in digital or 20mm in print horisontal lockup.",
+        "verticalNarrow": "Vertical lockup should never be narrower than 70px in digital or 15mm in print."
+      },
+      "logoSocialIcons": {
+        "title": "04. Social Icons",
+        "icon": "In cases when the Joystream brand has already been established we can simply use the icon on its own. While the icon can exist without the wordmark, the wordmark should never exist without the icon."
+      },
+      "logoForbiddenUses": {
+        "title": "05. Forbidden uses of the logo",
+        "rules": "The logotype and the icon must follow certain rules and there are general cases of use that should be avoided at all costs! In order to preserve the brand voice remember to avoid examples such as the following:"
+      },
+      "colorOverview": {
+        "combine": "Our brand colors combine three primary colors: black, white and blue. They define the mood and present brand values including:",
+        "example": "Stability, Trust, Freedom, Responsibility, Loyalty, Wisdom, Confidence and Intelligence"
+      },
+      "primaryColors": {
+        "title": "01. Primary Colors",
+        "blackAndBlue": "Our primarly used colors are black and Joystream blue, a distinctive color that helps to put focus and draw attention. The color white can be deployed in order to calm, provide clarity and offer improved readability.",
+        "blueGrey": "One additional color to combine with the three primary colors is blue tinted grey, its purpose is comparable to that of white but it also gives a good amount of contrast to the existing white elements where necessary."
+      },
+      "supportiveColors": {
+        "title": "02. Supportive Color Palette",
+        "purpose": "Our supportive palette serves the purpose of convenience and usability. This pallete provides a comprehensive range of different shades of primary colors and can be utilised in many different ways depending on requirements."
+      },
+      "secondaryColors": {
+        "title": "03. Secondary Color Palette",
+        "states": "These are further colours that can represent certain states of the network, they can stand for an error, success, warning and more."
+      },
+      "iconsOverview": {
+        "text": "Icons can be divided into two groups with different purposes. Descriptive icons are a substitute for illustrations and system icons are a purely functional part of the interface.",
+        "typeDescriptive": "01. Descriptive",
+        "typeSystem": "02. System"
+      },
+      "descriptiveIcons": {
+        "title": "01. Descriptive Icons",
+        "comprehensiveStyle": "Joystream iconography is a custom, comprehensive icon style that helps in explaining certain complex topics in a simple, digestable manner.",
+        "symbolic": "They are not always very direct and often carry a symbolic meaning but they help to emphasize important elements.",
+        "characteristicFeatures": "Characteristic features of the descriptive icons include paralell striped fills. They are a translation of logo stripes and represent shadows.",
+        "angle": "Lines have an angle of 45° they should have 2px girth and 8px space between them at 100% scale.",
+        "outlines": "Icons are drawn using outlines of 12px width at 100% scale, they have square linecaps and can have various sizes depending on the composition.",
+        "fit": "Icons at 100% scale should fit into a box of 800x500px."
+      },
+      "systemIcons": {
+        "title": "02. System Icons",
+        "basicStyle": "System icons in their basic style combine two colors: black and Joystream Blue. Their purpose is to represent certain actions on the website or platform. They are readable even in small sizes down to 18x18px.",
+        "strokes": "System Icons are drawn using 2px strokes with square linecaps on a 24px grid frame.",
+        "subtleAccents": "Where possible, icons should have subtle blue accents representing no greater than 40% of the whole.",
+        "types": "Types of system icons",
+        "fourTypes": {
+          "text": "We distinguish four types of system icons and they should be used preferably in their basic style but can be used interchangeably where neccessary.",
+          "basic": "Basic style",
+          "blue": "Blue outlines",
+          "white": "White outlines",
+          "full": "Full style"
+        }
+      },
+      "illustrations": {
+        "overview": "Joystream Illustrations are symbolic representation of important concepts within the Joystream project. These might include a a new testnet, a particular role on the network or any other equally significant subject.",
+        "complex": "They can be quite visualy complex despite using only three colors and no gradients.",
+        "patterns": "Illustrations will often be combined with patterns and in the case of putting them on a blue background, the outline of the illustration can be changed to Joystream Blue in order to create a good color balance between patterns and the background.",
+        "distinctive": "Illustrations should be simple enough to be distinctive even in smaller resolutions down to 300x300px.",
+        "adequateDetail": "The amount of detail should be adequate to what the illustration represents, in most cases they should be deployed at sizes no smaller than 500x500px."
+      },
+      "patterns": {
+        "translation": "Patterns are close translation of the logomark (J) into variants of geometrical shapes representing the flow of information, technology and Joystream's experimental brand personality.",
+        "supportTool": "They were introduced as a support tool to make certain elements stand-out, to build mood and as an inherent element of the visual identity of the brand.",
+        "sixPieces": "Patterns visually consist of six different pieces that can be rotated by 90 degrees in any direction and should always have the dimensions of a perfect square.",
+        "oneCommonVertex": "They should also have at least one common vertex when they touch. They do not always have to touch and when they don’t, space between pieces should always be equal to its’ width/height or the value multiplied.",
+        "howToUse": "How to use patterns",
+        "oneOfFive": "Patterns can use one of five different colors depending on what background is used beneath and what their main purpose is in a given situation.",
+        "density": "Depending on the situation these can be used more or less densely.",
+        "inUse": "Patterns in use - examples"
+      },
+      "typography": {
+        "overview": "Our typefaces are simple, comprehensive and modern. This is a reflection of our brand and our voice. We chose the appropriate typeface weights from PX Grotesk (regular, bold) and Inter family for specific touchpoints and to create clear hierarchies of information and messages.",
+        "backup": "If either two typefaces are impossible to use please choose Arial Regular. This may be required across PC operating systems or electronic internal documents or in diferent offices worldwide. Don’t use Arial for any print materials.",
+        "sample": "The following is a sample of an ideal font stack using PX Grotesk for headlines and larger pull quote text and Inter UI for paragraph and call-to-action text."
+      },
+      "photography": {
+        "overview": "Photographs should be relevant to the topic they are describing but they shouldn’t be limited only to technology. Joystream is much more than just technology; it is unifying, fresh and joyful. Imagery should convey this mood to users.",
+        "howToUse": "How to use photography",
+        "variety": "Since Joystream is a unique and experimental project it provides a wide variety of the topics which might be  associated with it in terms of photography. It is highly technical especially now when we are in the community building phase, so good deal of the photographs will be tech related.",
+        "consistency": "One way to make sure the photographs are consistent is to use them in dual tones deriving from branding colors. For that purpose we can use a handy tool to consistently change images to dual tones as described below.",
+        "consistentDuotones": "The link below allows you to create consistent duotones with any photography after inputing the proper two Joystream colours.",
+        "mood": "The mood that photos convey is extremely important. It should by all means give a feel of building trust, community and joy. Photographs should show good amount of diversity as it is meant to be for an extremely wide variety of users. They don’t have to be used in dual tones but it is best if they are not \"screaming\" with colours.",
+        "inUse": "Photography in use - examples"
+      },
+      "motion": {
+        "subtitle": "Joystream is an experimental and exciting platform and its motion should be too.",
+        "rules": "General rules for motion can be described with a few simple principles: smooth transitions, dynamic but fluid motion and good amount of easing at the keyframes. This combination should provide a consistent and flexible animation style to cover most of the use cases.",
+        "notLimiting": "Guides should be by no means limiting, they should only serve the purpose of providing consistency for animations."
+      }
+    },
+    "story": {
+      "header": {
+        "title": "Joystream Brand Story",
+        "description": "Joystream offers a modern, experimental solution to the problem of accountable governance in digital media. <0>Our objective is to build a user-governed video platform with a strong sense of community and freedom.</0>",
+        "buttonText": "Manifesto"
+      },
+      "website": {
+        "title": "The Website",
+        "linkText": "Visit the Website"
+      },
+      "description": {
+        "header": "Our brand identity consists of few key visual elements: our logo, typeface, illustrations, patterns, colour palette and iconography.",
+        "meaningfulRole": "Each of these elements has a meaningful role in brand identity as established in the guidelines. But combining all of these components builds much more than just a visual experience.",
+        "powerfulTool": "Joystream branding is a powerful tool for communication with all of its users throughout their whole experience.",
+        "experimental": "Fundamentally, our effort is an experimental one; we do not have all the answers, and we want to be honest about that in our communication.",
+        "empowering": "We are not promising cheaper, faster or nicer, like one typically would when selling a consumer widget or service. Instead we have hope that we can build something more empowering and accountable through our process of experimentation.",
+        "governance": "Lastly, at the core of our vision is governance, so what we are building is never finished; we are only constructing the first piece. It is a dynamic effort we hope communities will carry forward in amazing ways, we are just providing the first set of tools.",
+        "footer": "For the reasons outlined above, our brand should carry this feeling of experimentation, excitement and building something ethical and dynamic."
+      },
+      "logo": {
+        "title": "We want to free the media, inspire people and connect them using platform",
+        "uniqueness": "Creating the Joystream brand proved to be challenging due to its uniqueness and the fact that it is continually evolving.",
+        "requirements": "Not only did we have to take into account a very wide and diverse user base but also we had to create a brand that will be futureproof and flexible enough to cover both the existing and upcoming requirements of the project.",
+        "branding": "Joystream branding itself is quite metaphoric and symbolic, often referring to symbolism of ancient cities, culture, arts and philosophies.",
+        "challenge": "The challenge was to combine it with very modern and complex technologies."
+      },
+      "explanation": {
+        "title": "Explaining the Brand",
+        "balance": "Our new branding is about finding good balance between a very simplistic tone of communication with the symbolism and complexity of modern world problems and technologies.",
+        "patterns": "Our branding uses mosaic, geometrical patterns and shapes combined with explicit colours and symbolic  illustrations.",
+        "style": "We also deploy descriptive icons in combination with simple glyph style system icons and an experimental  illustration style."
+      }
+    },
+    "button": {
+      "text": {
+        "downloadLogo": "Download Logo"
+      }
+    }
+  }
+}

--- a/src/locales/es/constantinople.json
+++ b/src/locales/es/constantinople.json
@@ -1,0 +1,51 @@
+{
+  "constantinople": {
+    "siteMetadata": {
+      "description": "Explore the Constantinople testnet"
+    },
+    "hero": {
+      "title": "Constantinople Network",
+      "text": "The Constantinople testnet introduces an improved proposals system and fiat-backed token model for participant compensation.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ALEXANDRIA ON"
+    },
+    "modal": {
+      "title": "Constantinople",
+      "text": "The Column of Constantine, also known as the Burnt Stone or the Burnt Pillar, is a Roman monumental column constructed on the orders of the Roman emperor Constantine the Great in 330 AD. It commemorates the declaration of Byzantium as the new capital city of the Roman Empire."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Constantinople testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Constantinople testnet.",
+      "goals": {
+        "proposalSystem": {
+          "title": "Launch a new proposal system",
+          "text": "The constantinople testnet is built around the introduction of a proposal system that strengthens the governance structure of the platform, shifting the day to day responsibility of monitoring the network and allocating resources to voters and the council."
+        },
+        "tokenModel": {
+          "title": "Introduce a fiat-backed token model",
+          "text": "Constantinople introduces a new incentive structure, with a fiat (USD) pool backing the testnet tokens, setting up a more realistic economic system for the platform."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Constantinople Network"
+    },
+    "map": {
+      "title": "Constantinople",
+      "text": "<0>Constantinople was the capital city of the Eastern Roman Empire during the fourth century.</0> It was famed for its massive and complex defences as well as its architectural masterpieces and opulent aristocratic palaces. As was the case with the city, we hope our Constantinople testnet will be a worthy successor to Rome.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/es/dashboard.json
+++ b/src/locales/es/dashboard.json
@@ -1,0 +1,17 @@
+{
+    "dashboard" : {
+        "siteMetadata" : {
+            "title" : "Live Dashboard",
+            "description" : "Data compiled from current Pioneer and Atlas instances and visualized through charts."
+        },
+        "title" : "Joystream Dashboard",
+        "subtitles" : {
+            "videos" : "Videos",
+            "channels" : "Channels",
+            "users" : "Users",
+            "posts" : "Posts",
+            "threads" : "Threads"
+        },
+        "amount" : "Amount"
+    }
+}

--- a/src/locales/es/founding-members.json
+++ b/src/locales/es/founding-members.json
@@ -1,0 +1,171 @@
+{
+  "foundingMembers": {
+    "general": {
+      "foundingMembers": "Founding Members",
+      "nonFoundingMembers": "Non-Founding Members",
+      "directScore": "Direct Score",
+      "referralScore": "Referral Score",
+      "totalScore": "Total Score",
+      "inducted": "Inducted",
+      "member": "Member",
+      "backButton": "Back to Program page",
+      "before": "Before",
+      "account": "Account",
+      "next": "Next",
+      "howItWorks": "How it works.",
+      "inputPlaceholder": "e.g. joedoe",
+      "inductionDate": "Induction Date",
+      "joinOurDiscord": "Join our Discord"
+    },
+    "scoringPeriod": {
+      "title": "Current scoring period",
+      "currentNumber": "Current period number",
+      "ends": "ENDS",
+      "endedOn": "ENDED ON",
+      "weeks": "WEEKS",
+      "days": "DAYS",
+      "hours": "HOURS",
+      "minutes": "MINUTES",
+      "submitSummary": "Submit Summary",
+      "periodAnnouncement": "Period Announcement",
+      "announcement": "Announcement"
+    },
+    "landing": {
+      "siteMetadata": {
+        "title": "Founding Members",
+        "description": "Information and data regarding the new Founding Members Program of the Joystream platform."
+      },
+      "hero": {
+        "title": "Joystream Founding Member Program",
+        "text": "Founding Members are highly effective project contributors awarded JOY tokens in the mainnet genesis block.",
+        "imageAlt": "founding members visual"
+      },
+      "list": {
+        "currentMembers": "Current founding members",
+        "newMembers": "New founding members",
+        "iconAlt": "icon of founding member"
+      },
+      "benefits": {
+        "title": "What is the Founding <0/> Member Program <0/> and why does it exist?",
+        "currentlyBuilding": "While Jsgenesis is the team currently building the technology behind the Joystream project, we will not be around forever, and we are instead entrusting the future operation of the Joystream DAO to our community members.",
+        "foundingMembers": "The Founding Member Program formally allocates JOY tokens among some of our highest quality community members in recognition of their contributions to the project and ensures that a sufficiently large, effective and motivated community of users is ready to occupy all the different roles required to run, evolve and grow the platform on mainnet.",
+        "benefits": "Benefits",
+        "benefitsAlternate": "Benefits of becoming a founding member",
+        "payout": {
+          "title": "Tokens",
+          "text": "allocated tokens in the genesis block of the Joystream mainnet as a result of high quality participation and recruiting other participants"
+        },
+        "membership": {
+          "title": "Membership Status",
+          "text": "special status membership assigned in genesis block, which will have a visually distinguished presentation in Pioneer and other products"
+        },
+        "avatar": {
+          "title": "Handcrafted Avatar",
+          "text": "receive a handcrafted premium membership avatar and be honoured on the official project website and social media leading up to mainnet"
+        },
+        "itemImageAlt": "benefit item"
+      },
+      "takePart": {
+        "title": "How to participate in the program",
+        "introduceYourself": {
+          "text": "Introduce yourself on Discord.",
+          "altText": "Introduce yourself in our Discord."
+        },
+        "contribute": {
+          "text": "Make contributions to the project.",
+          "contributions": "<0><0>training other participants</0><0>writing blog posts and documentation</0><0>creating and publishing new video content</0><0>participating in platform roles on the testnet</0><0>finding and reporting bugs and errors</0><0>completing official bounties</0><0>creative and design work</0></0>"
+        },
+        "report": "Regularly report your activity.",
+        "earnPoints": "Earn leaderboard points.",
+        "becomeFM": "Become a founding member!",
+        "buttonText": "Join Discord",
+        "excluded": "Countries that are excluded from that program: ",
+        "usFlagAlt": "us flag icon",
+        "tokensAlt": "two tokens"
+      },
+      "keyMetrics": {
+        "title": "Key metrics for the program",
+        "initialTokenPool": "size of initial token pool",
+        "numberOfFM": "number of founding members",
+        "numberOfCandidates": "number of founding member candidates",
+        "leaderboards": "Leaderboards",
+        "foundingMembersButton": "All Founding Member Scores",
+        "regularMembersButton": "All Regular Member Scores",
+        "fullProgramRules": "Read the full program rules"
+      },
+      "cta": {
+        "title": "Discuss the program",
+        "joinDiscord": "Begin your founding member journey by joining our Discord group and requesting your first testnet tokens.",
+        "askQuestions": "Here you can also ask question about many aspects of the program and find out the areas where you can contribute right away.",
+        "joinNow": "Join now",
+        "imageAlt": "founding members visual"
+      },
+      "disclaimer": {
+        "title": "Disclaimer",
+        "text": "This disclaimer applies to the webpage accessible at <0>www.joystream.org/token</0> as well as all other webpages, digital services or applications published by Jsgenesis (the “Company”). The disclaimer also applies to any material published by Company in any other format in connection with the JOY token (the “Token”). Publications made by Company and all information contained within them are not directed at or intended for use by any person resident or located in any jurisdiction where (1) the distribution of such information is contrary to the laws of such jurisdiction; or (2) such distribution is prohibited without obtaining the necessary licenses or authorizations by the relevant branch, subsidiary or affiliate office of Company and such licenses or authorizations have not been obtained. Company does not provide investment, legal or tax advice and nothing herein should be construed as being financial, legal, tax or other advice. Unless specifically stated otherwise, all price information is indicative only. No representation or warranty, either express or implied, is provided in relation to the accuracy, completeness or reliability of the materials, nor are they a complete statement of the securities, markets or developments referred to herein. The materials should not be regarded by recipients as a substitute for the exercise of their own judgment. All information and materials published, distributed or otherwise made available by Company in relation to Token are provided for informational purposes, for your non-commercial, personal use only. No information or materials published by Company constitutes a solicitation, an offer, or a recommendation to buy or sell any investment instruments, to effect any transactions, or to conclude any legal act of any kind whatsoever."
+      }
+    },
+    "leaderboards": {
+      "siteMetadata": {
+        "title": "Founding Members Leaderboards"
+      },
+      "title": "Leaderboard"
+    },
+    "form": {
+      "siteMetadata": {
+        "title": "Founding Members Form"
+      },
+      "title": "Submit activity summary",
+      "progressItem": {
+        "accountInfo": "Account info",
+        "keyFile": "Key file",
+        "summary": "Summary",
+        "acceptTerms": "Accept terms & conditions",
+        "acceptTermsShort": "Terms & cond."
+      },
+      "membership": {
+        "membershipHandle": "Membership handle",
+        "avatarAlt": "founding member avatar"
+      },
+      "json": {
+        "exportedAccount": "Exported account with key",
+        "howToExport": {
+          "link": "How to export your key?",
+          "title": "How to export your account with key:",
+          "text": "In the <0>Pioneer application</0> click the <1>My Keys</1> tab and then click the ellipsis (three dots) button on the Key which you would like to use. Then click <1>Create a backup file for this account</1>. Enter your password (if applicable) and the JSON will be downloaded."
+        },
+        "fileFormat": "Accepted file format: .json"
+      },
+      "keybaseAndText": {
+        "keybaseHandle": "Keybase handle",
+        "documentWithSummary": "Document with the summary",
+        "howToPrepare": {
+          "link": "How should I prepare it?",
+          "alternateLink": "How should I do it?",
+          "title": "How to prepare it:",
+          "text": "Your activity summary should describe in as much detail as possible your recent contributions to the success of the platform. Try to separate out each contribution into a separate paragraph or bullet point for ease of processing."
+        },
+        "fileFormat": "Accepted file format: .txt",
+        "password": "Password",
+        "pleaseEnterPassword": "Please enter your password!"
+      },
+      "termsAndConditions": {
+        "title": "Read and accept terms and conditions",
+        "text": "<0>Term</0><1>The Joystream Founding Member Program was formally launched during February 2021. The program will stop accepting new submissions (activity summaries) and awarding further leaderboard points approximately one month in advance of the mainnet launch, on the snapshot date, yet to be confirmed.</1><2><0>Our current target for mainnet launch is during Q4 2021, though this is subject to change.</0></2><0>Eligibility</0><1>The program is open to everyone over the age of 18 who are not U.S. persons. </1><1>To be formally admitted to the program you will be contacted and screened by a Jsgenesis representative once your community contributions have met our internally determined threshold for admission.</1><2>The formal admission of new Founding Members to the program will take place at the end of scoring periods (the dates of which are published on our website). Each scoring period currently lasts two weeks.</2><0>Communication</0><1>We will publish further public updates about the program through our regular communication channels, including our Official Discord Channel, the Joystream Newsletter, the official GitHub repo for the program (github.com/joystream/founding-members) and on our website (www.joystream.org), and blog (blog.joystream.org).</1><2>Any private or sensitive information about your participation in the program will be communicated via Keybase or some other previously agreed contact method.</2><0>Token Allocation Formula</0><1>Once officially awarded with Founding Member status, you will be automatically assigned 0.02% of the mainnet genesis token supply. The rest of your token allocation will be calculated based on your proportional share of leaderboard points among all Founding Members.</1><2>Since the current program provides a token pool of 15%, this 15% will be made up of claims of the default 0.02% by each participant, and the remaining allocation not already claimed under this rule will be distributed proportionally based on the relative share of total leaderboard points for each Founding Member.</2><0>Reward Policy</0><1>Points have no intrinsic value and when assigned to users with the Founding Member status they only represent a partial claim on an as yet undetermined quantity of mainnet JOY tokens. In the case of bad faith activity (see below), leaderboard/founding member points can be voided at any time.</1><2>Participants should also be aware that tokens allocated for mainnet may include some vesting period or \"locks\", that restricts what they can be used for some period of time.</2><0>Eviction Policy</0><2>Any platform member who participates in fraudulent or bad faith activity is liable to be expelled from the leaderboards and Founding Member program, with all associated token claims voided.</2><0>Account and Key Security</0><1>Your leaderboard/founding member points are yours alone and are non-transferrable. You must keep your account and any private keys associated with your membership of the Founding Member program safe and engage in sensible digital security practices.</1><1>Keys with associated Founding Member token claims must not be transferred to anyone else under any circumstances. Where this occurs, points or token claims may be voided (see above).</1><2>Tokens can only be allocated to addresses under your control. You may be required to sign a message proving you own the private keys to any addresses you provide.</2><0>Activity Reporting</0><1>You cannot claim for the same activity on more than one occasion (i.e. across more than one summary) in order to be awarded the same points twice. If this does occur it is liable to be deemed bad faith and may result in your eviction from the program.</1><1>All activity must be reported within 30 days of taking place. Contributions recorded outside of this window will not qualify for rewards. For this reason it is very important to submit regular summaries.</1><1>Once you have submitted your activity up to and including a certain date, you can no longer submit activity from before this date.</1><2>When reporting contributions, the correct format for summary submissions should be observed.</2><0>Updates To These Rules</0><1>Jsgenesis reserves the right to update the rules of the program at any time, for any reason.</1><1>If serious flaws in the structure of the program are discovered, Jsgenesis reserves the right to announce that after a future scoring period, the \"season\" is concluded, and a new scheme will apply to following seasons, thus resetting \"scores\". In such an event, a \"slice\" of the pool, set by Jsgenesis discretion, will be allocated in accordance with existing rules. The remainder will be transferred to new \"seasons\".</1><1>Jsgenesis reserves the right not to honour any aspect of this agreement due to legal considerations.</1>"
+      },
+      "success": {
+        "title": "Thank you for submitting your summary, we have received it successfully.",
+        "text": "We will process the information contained within it shortly and award leaderboard points for qualifying contributions."
+      },
+      "error": {
+        "noSuchAccount": "No such account exists. Try again!",
+        "incorrectPassword": "Password is incorrect, please try again!",
+        "fileFormat": "Wrong file format! Please try again or check our tips how to export it.",
+        "jsonWrongAccount": "Json file doesn't correspond to account given!",
+        "faultyJson": "Json file has incomplete/incorrect components. Try exporting your account again!"
+      },
+      "dropFile": "Drop you file here or <0>browse files</0>",
+      "uploadFile": "Upload file"
+    }
+  }
+}

--- a/src/locales/es/general.json
+++ b/src/locales/es/general.json
@@ -1,0 +1,135 @@
+{
+  "joystream": "Joystream",
+  "button": {
+    "getStarted": {
+      "text": "Start earning",
+      "altText": "Join & start earning"
+    },
+    "download": "Download",
+    "close": "Close",
+    "accept": "Accept",
+    "openDiscord": "Open Discord",
+    "learnMore": "Learn More",
+    "gettingStarted": "Getting Started"
+  },
+  "rolesData": {
+    "validator": "Validator",
+    "council": "Council",
+    "councilMember": "Council Member",
+    "storageProvider": "Storage Provider",
+    "contentCreator": "Content Creator",
+    "contentCurator": "Content Curator",
+    "discoveryProvider": "Discovery Provider",
+    "bandwidthProvider": "Bandwidth Provider",
+    "builder": "Builder",
+    "storageLead" : "Storage Lead",
+    "contentLead" : "Content Lead"
+  },
+  "siteMetadata": {
+    "title": "Joystream: The video platform DAO"
+  },
+  "colors": {
+    "joystreamBlue": "Joystream Blue",
+    "white": "White",
+    "joystreamGrey": "Joystream Grey",
+    "black": "Black"
+  },
+  "CMYK": "CMYK",
+  "RGB": "RGB",
+  "HEX": "HEX",
+  "orderedNumbers": {
+    "one": "01.",
+    "two": "02."
+  },
+  "numbers": {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7"
+  },
+  "roleCard": {
+    "migration": "At migration, {{numberOfUsers}} (max) had this role",
+    "current": "{{numberOfUsers}} run this role on Antioch",
+    "most": "At most, {{numberOfUsers}} users occupied this role",
+    "new": "NEW"
+  },
+  "heroCard": {
+    "active": "Network announced",
+    "error": "Network down",
+    "info": "Network replaced",
+    "finished": "Network live"
+  },
+  "dateCounter": {
+    "week": "week",
+    "weeks": "weeks",
+    "day": "day",
+    "days": "days",
+    "hour": "hour",
+    "hours": "hours",
+    "minute": "minute",
+    "minutes": "minutes",
+    "second": "second",
+    "seconds": "seconds",
+    "month": "month",
+    "months": "months",
+    "year": "year",
+    "years": "years",
+    "timeToLaunch": "Time to launch",
+    "launchedOn": "Launched on"
+  },
+  "sidebar": {
+    "activeRoles": "Active roles",
+    "upcomingRoles": "Upcoming roles",
+    "viewAllRoles": "View all Roles"
+  },
+  "navbar": {
+    "product": "Product",
+    "atlas": "Atlas",
+    "pioneer": "Pioneer",
+    "community": "Community",
+    "brandStory": "Brand Story",
+    "brandGuides": "Brand Guides",
+    "downloadAssets": "Download Assets",
+    "about": "About"
+  },
+  "footer": {
+    "title": "Stay up to date",
+    "alternateTitle": "Get notified",
+    "subtitle": "Don't worry about spam! Keep track of all important updates",
+    "inputPlaceholder": "Email Address...",
+    "joinNewsletter": "Join the newsletter",
+    "github": {
+      "whitepaper": "Whitepaper",
+      "repository": "Repository"
+    },
+    "usefulLinks": {
+      "title": "Useful links",
+      "hiring": "We are hiring!",
+      "brandGuidance": "Brand guidance"
+    },
+    "followUs": "Follow us"
+  },
+  "pages": {
+    "blog": "Blog",
+    "manifesto": "Manifesto",
+    "roles": "Roles",
+    "token": "Token",
+    "hydra": "Hydra",
+    "foundingMembers": "Founding Members",
+    "leaderboards": "Leaderboards",
+    "scoringForm": "Scoring form",
+    "overview": "Overview"
+  },
+  "socials": {
+    "twitter": "Twitter",
+    "github": "GitHub",
+    "discord": "Discord"
+  },
+  "cookiesNotice": {
+    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "findOutMore": "Find out more ›"
+  }
+}

--- a/src/locales/es/get-started.json
+++ b/src/locales/es/get-started.json
@@ -1,0 +1,56 @@
+{
+  "getStarted": {
+    "siteMetadata": {
+      "title": "Getting Started",
+      "description": "Learn how to contribute and participate to the Joystream project"
+    },
+    "hero": {
+      "title": "How to Contribute and Participate",
+      "subtitle": "Read more about the current ways you can add value to the project and earn rewards for doing so.",
+      "buttonText": "View opportunities",
+      "imageAlt": "getting started hero"
+    },
+    "howToStart": {
+      "title": "How to start",
+      "discord": "Join our Discord",
+      "tokens": "Receive free testnet tokens",
+      "membership": "Create membership on-chain",
+      "opportunities": "Pick one of the opportunities below"
+    },
+    "opportunities": {
+      "title": "Opportunities",
+      "bounties": {
+        "title": "Bounties",
+        "text": "Bounties are long running tasks which anyone can attempt to tackle in a exchange for some reward. They are created either by Jsgenesis, or by the Council.",
+        "imageAlt": "money pouch"
+      },
+      "bountiesCarousel": {
+        "all": "All",
+        "coding": "Coding",
+        "design": "Design",
+        "marketing": "Marketing",
+        "research": "Research",
+        "contentCreation": "Content Creation"
+      },
+      "roles": {
+        "title": "Roles",
+        "text": "Our current testnet also allows you to participate in some of the platform roles which will be available on mainnet.<0/><0/>Participation in these roles is rewarded in tJOY (our testnet token) which is backed by fiat reserves at Jsgenesis and redeemable for bitcoin cash.",
+        "imageAlt": "masks"
+      }
+    },
+    "activeRoles": {
+      "title": "Active roles on the current testnet",
+      "validatorText": "A Validator is an actor which checks the validity of newly constructed blocks, proposes new blocks and participates in the consensus process for committing new block to the chain. Validators are typically paid a fixed amount for each block produced. This role has a purpose very similar to that of the miners in the Bitcoin blockchain.",
+      "councilMemberText": "Council Members are elected by stakeholders in the system to act in the long-term interest of the platform. They are responsible for allocating resources, and hiring working group leads to run the platform's day-to-day operations. This is done through the proposal system, allowing any user to submit suggestions for changing the platform in some way.",
+      "storageProviderText": "There are critical platform assets that do not live on the blockchain, such as content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enable uploading and downloading of such data. The Storage Provider is involved this activity, specifically by storing large quantities of data.",
+      "storageLeadText": "The Storage Lead is hired directly by the Council through the proposals system and is dedicated to the hiring, firing and wider management of Storage Providers on the network.",
+      "contentCuratorText": "Content Curators are responsible for monitoring the publishing of new content into the content directory, and responding to reports about contested publications. They must also update information on content to ensure it is accurate, with correct metadata. Collaborating with Builders to improve tools and user-facing experiences is another significant part of the role.",
+      "contentCreatorText": "Content Creators are those platform participants who have decided to contribute their own original (or third-party licensed) content to the platform. There are no direct incentives for this informal role at this time, though effective contributors are very likely to be rewarded through the Founding Member Program.",
+      "contentLeadText": "The Council has the power to appoint a Content Curator Lead for the network who can hire further Content Curators. The Content Lead also decides on priorities for curation. If necessary, upon discussing with the council, the Lead can also decide to fire curators who are not performing their jobs adequately."
+    },
+    "roleCard": {
+      "overview": "Overview",
+      "buttonText": "Check details on GitHub"
+    }
+  }
+}

--- a/src/locales/es/hydra.json
+++ b/src/locales/es/hydra.json
@@ -1,0 +1,98 @@
+{
+  "hydra": {
+    "siteMetadata": {
+      "title": "Hydra - A Substrate query node framework",
+      "description": "Inspired by The Graph, it gives a smooth way to provide powerful GraphQL queries to app developers over your Substrate blockchain state and history."
+    },
+    "hero": {
+      "title": "Hydra - A Substrate query node framework",
+      "text": "Inspired by The Graph, it gives a smooth way to provide powerful GraphQL queries to app developers over your Substrate blockchain state and history."
+    },
+    "value": {
+      "title": "We make it simple",
+      "subtitle": "Building great apps talking directly to a Substrate full node is impossible, and simply trying is slow and hard.",
+      "values": {
+        "slowFetching": {
+          "title": "Slow Fetching",
+          "text": "Doing multiple read operations across multiple block heights is often required, and the pure latency of fetching the data is very bad. Some reads may depend on the result of prior ones, which results in sequential reads, which is even slower."
+        },
+        "slowProcessing": {
+          "title": "Slow Processing",
+          "text": "The client has to do all the work of filtering, sorting, paginating or otherwise computing on the resulting data, and this takes time, resulting in a slow client experience and CPU load on the user device."
+        },
+        "complexClient": {
+          "title": "Complex Client",
+          "text": "The fetching and processing logic is reproduced in all apps, and adds to the complexity of application development."
+        },
+        "noSearch": {
+          "title": "No Search",
+          "text": "Your chain may have transactional or state commitments to free-text data, but doing real full-text search client-side is not an option."
+        },
+        "overFetching": {
+          "title": "Over-Fetching",
+          "text": "You cannot select the data you want, you have to read full state objects as they are, wasting both connection and full node capacity."
+        },
+        "costlyNodes": {
+          "title": "Costly Archival Nodes",
+          "text": "User requests which involve multiple read operations. To fetch a consistent dataset, you will often have to read at some specific block height, as always reading at the tip can break atomicity. This means such read requests will depend on the full node being archival. As your user base scales, that will become a very costly infrastructure."
+        }
+      }
+    },
+    "snippet": {
+      "title": "Powerful queries in GraphQL",
+      "subtitle": "Provide application developers a powerful GraphQL API for your blockchain state and history"
+    },
+    "features": {
+      "title": "Hydra Features",
+      "values": {
+        "fullTextSearch": {
+          "title": "Full-text Search",
+          "text": "Decorate any number of String fields in the input schema with @fulltext(query: \"myquery\") to seach across different fields and entities."
+        },
+        "filtering": {
+          "title": "Filtering",
+          "text": "Any entity field can be used for OpenCRUD filtering"
+        },
+        "pagination": {
+          "title": "Pagination",
+          "text": "Each GraphQL query supports pagination out-of-the-box"
+        },
+        "ordering": {
+          "title": "Ordering",
+          "text": "Order by any primitive field"
+        },
+        "polymorphism": {
+          "title": "Polymorphism",
+          "text": "Native support of GraphQL interfaces and type inline fragments"
+        },
+        "algebraicTypes": {
+          "title": "Algebraic Types",
+          "text": "Construct rich and queriable algebraic types with @variant directive"
+        }
+      }
+    },
+    "videoTitle": "Play a video tutorial",
+    "getStarted": {
+      "title": "Get started with Hydra now!",
+      "subtitle": "Use the following links to connect with us and find out even more.",
+      "links": {
+        "documentation": {
+          "name": "Documentation",
+          "link": "Documentation"
+        },
+        "githubRepository": {
+          "name": "Github Repository",
+          "link": "Github repo"
+        },
+        "kusamaPlayground": {
+          "name": "Kusama Playground",
+          "link": "Go to the Playground"
+        },
+        "discord": {
+          "name": "Discord",
+          "link": "Go to the Channel"
+        }
+      }
+    }
+  }
+}

--- a/src/locales/es/landing.json
+++ b/src/locales/es/landing.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "siteMetadata": {
+      "description": "Joystream is a video platform controlled, owned, and operated by its users."
+    },
+    "hero": {
+      "title": "The video platform DAO",
+      "subtitle": "Joystream is a video platform controlled,<0/> owned, and operated by its users",
+      "metrics": {
+        "mainTitle": "Testnet Metrics",
+        "titles": {
+          "participationPayout": "Participation Payout",
+          "activeValidators": "Active Validators",
+          "blockHeight": "Block Height",
+          "memberships": "Memberships"
+        }
+      }
+    },
+    "becomeFM": {
+      "subtitle": "Our brand new and unparalleled community token distribution scheme",
+      "title": "Become a Founding Member to earn mainnet tokens and influence the development of the platform.",
+      "alternateTitle": "Become a Founding member and have a tangible impact on the development of our platform.",
+      "link": "Learn more about our generous program"
+    },
+    "whatWeDo": {
+      "subtitle": "Our motivation for building the Joystream protocol",
+      "title": "We call for an arrangement where media platforms are accountable to the people they impact.",
+      "link": "Read our manifesto"
+    },
+    "whyYouShouldJoin": {
+      "title": "Why join our testnets?",
+      "reasons": {
+        "tokens": {
+          "title": "Tokens",
+          "text": "Earn tokens distributed on mainnet, launching 2021"
+        },
+        "cash": {
+          "title": "Cash",
+          "text": "Get rewarded with real money for your participation"
+        },
+        "reputationAndSkill": {
+          "title": "Reputation & Skill",
+          "text": "Gain the knowledge required to participate on mainnet"
+        }
+      }
+    },
+    "exploreJoystream": {
+      "title": "Explore Joystream Now",
+      "subtitle": "Two fast evolving apps for consuming content and governance activities.",
+      "atlas": {
+        "text": "Atlas is the flagship content consumer and publishing app for Joystream. Watch videos, follow creators and discover new featured content, or create a channel and build your audience.",
+        "link": "Try out Atlas",
+        "imageAlt": "overview visual of Atlas"
+      },
+      "pioneer": {
+        "text": "Pioneer is the place to participate in community governance and operation. Vote on elections, submit proposals to fund your project or get enter a paid role to power the platform.",
+        "link": "Try out Pioneer",
+        "imageAlt": "overview visual of Pioneer"
+      }
+    },
+    "roadToMainnet": {
+      "title": "Road to mainnet",
+      "testnetState": {
+        "Current": "Current testnet",
+        "Past": "Past testnet",
+        "Future": "Future testnet"
+      },
+      "released": {
+        "Current": "Released on ",
+        "Past": "Released on ",
+        "Future": "Will be live on "
+      },
+      "testnets": {
+        "Sparta": {
+          "title": "Sparta testnet",
+          "text": "Sparta is our second testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Sparta"
+        },
+        "Athens": {
+          "title": "Athens testnet",
+          "text": "Athens is our third testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Athens"
+        },
+        "Acropolis": {
+          "title": "Acropolis testnet",
+          "text": "Acropolis is our fourth testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Acropolis"
+        },
+        "Rome": {
+          "title": "Rome testnet",
+          "text": "Rome is our second fifth, introducing a variety of important technical improvements.",
+          "explore": "Explore Rome"
+        },
+        "Constantinople": {
+          "title": "Constantinople testnet",
+          "text": "Constantinople is our sixth testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Constantinople"
+        },
+        "Alexandria": {
+          "title": "Alexandria testnet",
+          "text": "Alexandria is our second seventh, introducing a variety of important technical improvements.",
+          "explore": "Explore Alexandria"
+        },
+        "Babylon": {
+          "title": "Babylon testnet",
+          "text": "Babylon is our second eighth, introducing a variety of important technical improvements.",
+          "explore": "Explore Babylon"
+        },
+        "Antioch": {
+          "title": "Antioch testnet",
+          "text": "Antioch is our ninth testnet, patching a chain split bug which broke the Babylon network",
+          "explore": "Explore Antioch"
+        },
+        "Sumer": {
+          "title": "Sumer testnet",
+          "text": "Sumer is our tenth testnet, facilitating easy content uploads via our playback app.",
+          "explore": "Explore Sumer"
+        }
+      }
+    },
+    "earnTokens": {
+      "title": "Earn mainnet tokens, cash and influence."
+    }
+  }
+}

--- a/src/locales/es/manifesto.json
+++ b/src/locales/es/manifesto.json
@@ -1,0 +1,72 @@
+{
+  "manifesto": {
+    "siteMetadata": {
+      "description": "Read the Joystream Manifesto"
+    },
+    "hero": {
+      "title": "The Joystream Manifesto",
+      "text": "Our Manifesto sets out both the problems we believe are associated with digital media platforms in their current form as well as our proposed solution to these concerns."
+    },
+    "problem": {
+      "title": "Problem",
+      "text": {
+        "artAsTool": "We believe that art, be it as literature, music, film, games or performance, is a critical tool through which societies establish a shared understanding of what is common knowledge among all members. These expressions define values and narratives that end up shaping culture, faith and even public policy. It therefore matters deeply how it is financed, distributed and paid for.",
+        "mediaAsPrimaryMedium": "Digital media has become the primary medium through which such expression is distributed, and digital media platforms have become the key institutions organizing this activity.",
+        "unaccountableInstitutions": "Unfortunately, due to network effects, economies of scale, regulations and political interests, we are today left with handful of massive institutions which set the terms for how this happens. They are almost entirely unaccountable to normal market and political mechanisms.",
+        "filteredOnTheirTerms": "As a result, our stories, expressions and interactions are managed and filtered on their terms. This continues to generate an ever changing set of problems, be it",
+        "inflexible": "inflexible monetization, censorship of controversial speech, inequitable sharing of gains with creators and audience, low platform innovation or lack of credibility with third party developers."
+      }
+    },
+    "goal": {
+      "title": "Goal",
+      "text": {
+        "arrangement": "We call for an arrangement where media platforms are accountable to the people they impact, which are primarily their users, be it as consumers, creatives, third party developer or workers.",
+        "accountability": "It is the absence of such accountability which is the fundamental source of any particular problem at any particular time."
+      }
+    },
+    "thesis": {
+      "title": "Thesis",
+      "text": {
+        "coreThesis": "Our core thesis is that there are two basic challenges which must be addressed to achieve this goal, and that an appropriate application of contemporary distributed systems technology, including blockchains, smart contracts and tokens, is the right means to do so."
+      }
+    },
+    "wedge": {
+      "title": "The Wedge",
+      "text": {
+        "alternative": "First is the question of how to create an alternative from scratch in the face of platform externalities which make any new platform nearly useless, regardless of any of its inherent characteristics. The process of doing this sort of bootstrapping has historically been mostly an art, where success has rarely been reproducible.",
+        "blockchainTokens": "We believe that blockchain tokens, earned by and issued to early participants, have been shown to be extremely effective at mobilizing, integrating and motivating an international and dynamic community.",
+        "initialHurdle": "This has now repeatedly allowed nascent communities, like the Bitcoin community, to overcome the initial network effect hurdle [1, 2, 3]. There is no certainty that this will be sufficient, but we believe this mechanism is as promising as anything which is likely to have a chance in a long time."
+      }
+    },
+    "accountability": {
+      "title": "Accountability at scale",
+      "text": {
+        "createAndSustain": "Second is the question of how to create and sustain accountability in such a platform when it actually reaches scale.",
+        "twoWays": "We understand there to be two fundamental ways that participants can hold institutions of any kind accountable: Voice and exit, in the tradition of Hirschman A. O. [4]."
+      }
+    },
+    "voice": {
+      "title": "Voice",
+      "text": {
+        "improveWithin": "Voice is the approach of attempting to improve or reform the functioning of an institution from within. The effectiveness of this depends on some capacity to both share reliable information with other members, and have some impact on internal governance processes. Current media platforms provide users no effective way of doing either.",
+        "infrastructure": "We believe that blockchains provide an organizational and economic infrastructure which can address both problems. The public, verifiable and immutable history of economic and administrative records, provides an excellent basis for users to understand the current and past state of the platform. This allows anyone to make incontestable claims about relevant facts and circumstances.",
+        "control": "Further, blockchain tokens allow us to make use and control of a platform inseparable, giving users an automatic seat at the table in deliberating over platform level decisions.",
+        "signWithCrypto": "All that is required to establish, exercise or transfer the capacity to participate in such activity, is the ability to sign messages with identifiable cryptographic keys. Perfectly reliable contracting gives a large, dynamic and unrestricted set of users the means of governing the platform. This can serve a wide range of purposes, such as undertaking projects, regulating participation in different formally specified roles, or even updating the institutional rules themselves. This integration of reliable contracting into the economic rails provides an organizational infrastructure much more in line with our objectives of inclusive control than the normal jurisdictional trust based infrastructure."
+      }
+    },
+    "exit": {
+      "title": "Exit",
+      "text": {
+        "exit": "Exit is the approach of entirely ending participation in an institution in favor of either joining or creating an alternative. The effectiveness of this depends on costs of leaving, and either joining or creating an alternative, all being low compared to the deprivation in the existing institution. This is currently not the case.",
+        "loweredCosts": "By building platforms based on free & open source software, open protocols and open data — as is the case with Blockchain systems, one dramatically lowers these costs. Since users control their own data, identity and assets, they have a much easier time joining new platforms, and even taking their peers with them.",
+        "competition": "Open protocols and data will make multi homing interfaces abundant, where users may not even need to switch, but instead use multiple platforms simultaneously, which encourages platform level competition [5].",
+        "reusability": "Even more dramatically, reliance on open source means that all the software capital of a platform can easily be reused, and since the entire organizational state is also public, entire ecosystems can be forked to create new alternative platforms with modified policies and objectives."
+      }
+    },
+    "ctaText": "This plan still has room for more people, so get involved by sending an <0>email</0> or joining us on <1>Discord</1> or <2>Reddit</2>.",
+    "references": {
+      "title": "References",
+      "text": "<0>[1] Ersam, F. Blockchain Tokens and the dawn of the Decentralized Business Model. Medium. Aug 1, 2016.</0><0>[2] Srinivasan, B. S. Thoughts on Tokens. Medium. May 27, 2017.</0><0>[3] Dixon, C. Crypto Tokens: A Breakthrough in Open Network Design. Medium. June 1, 2017.</0><0>[4] Hirschman, Albert O. Exit, voice, and loyalty: Responses to decline in firms, organizations, and states. Vol. 25. Harvard university press, 1970.</0><0>[5] Rochet, Jean‐Charles, and Jean Tirole. “Platform competition in two‐sided markets.” Journal of the european economic association 1.4 (2003): 990–1029.</0>"
+    }
+  }
+}

--- a/src/locales/es/privacy-policy.json
+++ b/src/locales/es/privacy-policy.json
@@ -1,0 +1,59 @@
+{
+  "privacyPolicy": {
+    "siteMetadata": {
+      "description": "Joystream Privacy and Cookie Policy"
+    },
+    "hero": {
+      "title": "Privacy Policy and Cookies",
+      "text": "<0><0>Jsgenesis values your privacy.</0><1/><1/>This Privacy Policy (\"Privacy Policy\") and Cookie Policy (\"Cookie Policy\") explains how Jsgenesis AS (\"Jsgenesis\", \"Company\", \"We\", \"Us\", \"Our\") collect and use data and information when you (\"User) use on or any of the Joystream products, developed in the GitHub organization <3>Joystream</3>. These products (collectively \"Software\") include, but are not limited to, all pages under the <6>joystream.org</6> domain (\"Website\"), the <10>Joyful node</10> (\"Full Node\"), the <14>Colossus Storage Node</14> (\"Storage node\"), and the Pioneer User Interface, either <18>self hosted</18> or <22>hosted by Us</22>  (\"App\").</0>"
+    },
+    "terms": {
+      "title": "Relevant to the Privacy Policy and Cookie Policy are the following terms:",
+      "blockchain": "The term <0>\"Blockchain\"</0> refers to the blockchain(s) assembled by the Full Node.",
+      "content": "The term <0>\"Content\"</0> refers to media files accessible through our Software.",
+      "keys": "The term <0>\"Keys\"</0> refers to a private/public cryptographic keypair, that Users can generate in order to write (and decrypt data) on the Blockchain.",
+      "membership": "The term <0>\"Membership\"</0> refers to tying your Keys to a public profile, allowing users to access Content and interact with the Blockchain.",
+      "memo": "The term <0>\"Memo\"</0> refers to a markdown enabled text field, where users can input data tied to their Keys."
+    },
+    "privacyPolicyItems": {
+      "title": "Privacy Policy",
+      "subtitle": "Last updated on the 17th of April 2019",
+      "agreement": {
+        "title": "1. Agreement to the Policy",
+        "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
+      },
+      "changes": {
+        "title": "2. Changes to Policy",
+        "content": "This Privacy Policy may be changed at the sole discretion of Company. If any material changes are made, the User will be notified in the Service that is used. Note that adding new products to be included in the term Software, e.g. a new User facing product replacing the App or a new tool for uploading Content, is not considered material as it will not affect Users unless they adopt the new product. Changing software names, terminology used in this Privacy Policy, and changing link locations are also examples of non-material changes."
+      },
+      "informationCollected": {
+        "title": "3. Information Collected",
+        "content": "All data written to the Blockchain, is implicitly collected not only by Company, but also anyone else in the world that is running the Full Node locally, or accessed via the App or a third party. This includes, but is not limited to, Content hashes, Membership profile, Memo field, and any other way a User can record data on the Blockchain. ‍<0/><0/> When using the <1>faucet</1> subpage of the Website, Company will record the IP address behind every new request for tokens. This data will be deleted every 14 days."
+      },
+      "googleAnalytics": {
+        "title": "",
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+      }
+    },
+    "cookiePolicyItems": {
+      "title": "Cookies Policy",
+      "subtitle": "Last updated on the 17th of April 2019",
+      "whatAreCookies": {
+        "title": "1. What are Cookies?",
+        "content": "Cookies are small pieces of text sent by your web browser by a website you visit. A cookie file is stored in your web browser and allows the Service or a third-party to recognise you and make your next visit easier and the Service more useful to you. ‍<0 />‍<0 /> Cookies can be persistent or session cookies."
+      },
+      "howWeUseCookies": {
+        "title": "2. How we use Cookies",
+        "content": "We use cookies for the following purposes our Service: <0 /><0 /><1><0>Provide Analytics</0><0>Store preferences</0><0>Persistant local storage of Keys and Membership.</0></1>"
+      },
+      "thirdPartyCookies": {
+        "title": "3. Third-party Cookies",
+        "content": "In addition to our own cookies, we also use various third-party cookies to report usage statistics of the Service, deliver advertisements on and through the Service, and so on. They include:<0/><0/><1><0><0>Google Analytics</0></0><0><0>Mailchimp</0> (Only when signing up for any of our newsletters)</0><0><0>Godaddy</0></0></1><0 />Please see Item 3. of the Privacy Policy for more information on the extent of these providers."
+      },
+      "regardingYourCookies": {
+        "title": "Regarding Your Cookies",
+        "content": "If you would like to delete cookies or instruct your web browser to delete or refuse cookies, please visit the help pages of your web browser.<0 />‍<0 /> Please note, however, that if you delete cookies or refuse to accept them, you might not be able to use all of the features we offer, you may not be able to store your preferences, and some of our pages might not display properly."
+      }
+    }
+  }
+}

--- a/src/locales/es/roles.json
+++ b/src/locales/es/roles.json
@@ -1,0 +1,197 @@
+{
+  "roles": {
+    "siteMetadata": {
+      "description": "Read more about current and future roles on the Joystream platform"
+    },
+    "hero": {
+      "title": "Choose your preferred role",
+      "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."
+    },
+    "validator": {
+      "title": "Validator",
+      "overview": "The Joystream platform state lives on a blockchain consensus system. This consensus system is a variant of classical BFT consensus combined with Proof-of-Stake to determine voting power. A validator is an actor which checks the validity of newly constructed blocks, proposes new blocks and participates in the consensus process for committing new block to the chain. This role has a purpose very similar to the miners in the Bitcoin blockchain. Importantly, anyone can fully check the validity of the blockchain, not just validators, and this is called validation.",
+      "responsibilities": {
+        "runAndMaintainScreeningNodes": "Run and maintain screening nodes that are always available and performant",
+        "enforceRules": "Help enforce the consensus rules of the network"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage, (up & down) bandwidth and processing capacity",
+        "storeKeys": "Able to securely store keys",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "councilMember": {
+      "title": "Council Member",
+      "overview": "At the heart of the governance process on the platform is the proposal system, which allows anyone to submit some suggestion for changing the state or policy of the platform in some way. These proposals are processed and voted on by a council, where the participants are referred to as council members. A seat on the council is won through an election process, and lasts for some period of time until a new election.",
+      "responsibilities": {
+        "discussProposals": "Discuss the meaning and merits of incoming proposals, covering a broad range of topics",
+        "vote": "Vote on proposals",
+        "representCommunity": "Represent the community members and your constituency to make day-to-day operations decisions"
+      },
+      "requirements": {
+        "dataAnalysisProficiency": "Proficiency with basic data analysis and sufficient reputation and standing within the community to earn supporting votes in elections from other platform members",
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure, function and resource allocation",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "storageProvider": {
+      "title": "Storage Provider",
+      "overview": "There are critical platform assets that do not live on the blockchain, such as images and content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enables uploading and downloading of such data. The storage provider is involved this activity, specifically by storing large quantities of data.",
+      "responsibilities": {
+        "runAndMaintainStorageNodes": "Run and maintain storage nodes that store very large quantities of static data, synchronize with other storage nodes, share data with distributors, and accepts inbound uploads from end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure with high storage capacity",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "storageLead": {
+      "title": "Storage Lead",
+      "overview": "The Storage Lead is hired directly by the Council through the proposals system and is dedicated to the hiring, firing and wider management of Storage Providers on the network.",
+      "responsibilities": {
+        "storageProviderPerformance": "The Storage Lead is responsible for ensuring that Storage Providers are performing adequately. Each one must hold a complete and up-to-date copy of the content directory and ensure uptime in order to effectively serve content consumers."
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "managementAndCoordination": "Ability to effectively manage and coordinate the actions of the Storage Providers",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentCurator": {
+      "title": "Content Curator",
+      "overview": "All of the media content published on the platform lives in an on-chain content directory. There are a range of different content types, and each type has a schema for a rich description of its structure, function and policies. For the effective use of of content, for example in rendering, discovery and monetization, it is critical to ensure the validity of the published information for all content. In particular, it is also important to resolve possible disputes about ownership and presence of any piece of content on the platform. It is the task of the content curators to do the work involved in processes that address these objectives.",
+      "responsibilities": {
+        "monitorContent": "Monitor the publishing of new content into the content directory, and respond to reports about contested publications",
+        "adjudicateDisputes": "Adjudicate possible dispute processes resulting from reports from users",
+        "updateContentInformation": "Update information on content to be accurate",
+        "collaborateWithBuilders": "Collaborate with <0> Builders</0> to improve both tools, and user facing experiences, to improve the integrity of the content directory"
+      },
+      "requirements": {
+        "adjudicateDisputes": "Fairly adjudicate disputes, and communicate in clear and transparent way with stakeholders and participants",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentCreator": {
+      "title": "Content Creator",
+      "overview": "As a video platform, one of the most important platform assets is the content published on the platform. Since video is such a flexible media type, which can encompass a wide range of content categories, it is the primary focus. However, the intention is to support a broader range of content types over time. The content creators are those involved in creating, publishing and monetizing content on the platform.",
+      "responsibilities": {
+        "publishContent": "Publish content and build an audience"
+      },
+      "requirements": {
+        "publishContent": "Have the right to publish existing or new content to the platform",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentLead": {
+      "title": "Content Lead",
+      "overview": "The Council has the power to appoint a Content Curator Lead for the network who can hire further Content Curators. The Content Lead also decides on priorities for curation. If necessary, upon discussing with the council, the Lead can also decide to fire curators who are not performing their jobs adequately.",
+      "responsibilities": {
+        "monitorPublishing": "Monitor the publishing of new content into the content directory, and respond to reports about contested publications",
+        "adjudicateDisputes": "Adjudicate possible dispute processes resulting from reports from users",
+        "updateInformation": "Update information on content to be accurate",
+        "manageAndCoordinate": "Manage and coordinate the actions of the Content Working Group"
+      },
+      "requirements": {
+        "adjudicateDisputes": "Fairly adjudicate disputes, and communicate in clear and transparent way with stakeholders and participants",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "membershipScreener": {
+      "title": "Membership Screener",
+      "overview": "A membership is an integrated representation of identifying information and associated activities of an actor on the platform. The direct way of establishing membership will be to simply pay a one time fee. However, since its currently challenging for many prospective non-technical end users to obtain, store and use crypto assets, there will be a way for users to get a membership for free, which will not require any tokens in order to use the platform in a limited capacity. The membership screener is the role responsible for granting such memberships, while screening for Sybill attackers and abusers.",
+      "responsibilities": {
+        "runAndMaintainScreeningNodes": "Run and maintain screening nodes that are always available and performant",
+        "collaborate": "Collaborate with <0>Membership Curators</0> and <1>Builders</1> to improve screening mechanisms by discussing screening techniques, sharing traffic information",
+        "beResponsive": "Be responsive and reactive to changing circumstances"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage, (up & down) bandwidth and processing capacity",
+        "onlinePlatformAttackFamiliarity": "Familiarity with how online platforms are attacked through botnets, IP anonymization, automated agents, etc.",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "membershipCurator": {
+      "title": "Membership Curator",
+      "overview": "A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described <0> above</0>. Since this is invariably an imperfect process, there must be some means by which bad conduct and fake accounts can be disabled or removed. This is the task of the membership curators.",
+      "responsibilities": {
+        "monitorPlatformActivity": "Monitor platform level activity for abuse and collusion",
+        "proposeChanges": "Propose changes to status of memberships which are identified, and participate in any dispute process which may follow",
+        "collaborate": "Collaborate with <0> Screeners</0> and <1> Builders</1> to improve tools for identifying such members"
+      },
+      "requirements": {
+        "dataAnalysisProficiency": "Proficient with basic data analysis and scripting",
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure, function and attack vectors",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "bandwidthProvider": {
+      "title": "Bandwidth Provider",
+      "overview": "There are critical platform assets that do not live on the blockchain, such as images and content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enable uploading and downloading of such data. The bandwidth provider is involved this activity, specifically by distributing static data to end users at scale.",
+      "responsibilities": {
+        "runAndMaintainDistributorNodes": "Run and maintain distributor nodes that deliver large volumes of upstream data to a large number of simultaneous end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage capacity and a lot of upstream capacity",
+        "locatedWithinBounds": "Located within certain bounds to designated geographic areas, in order to limit latency",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "discoveryProvider": {
+      "title": "Discovery Provider",
+      "overview": "All of the content on the platform is in a designated content directory, and effectively navigating this directory requires a full copy of this directory. Moreover, in order to do things like search and context based recommendations one needs to apply some sort of heuristic on top of this directory, which is also some what sensitive abusive attempts to rank higher. The discovery providers play the role of responding to such discovery queries to end users, by combining light client inclusion proofs with local search and ranking policy heuristics.",
+      "responsibilities": {
+        "runAndMaintainDiscoveryNodes": "Run and maintain discovery nodes that respond to discovery-related queries by staying in sync with the content directory, and applying local ranking heuristics.",
+        "collaborate": "Collaborate with <0>Builders</0> to improve both tools, and user facing experiences, to improve the discovery experience"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure",
+        "formulateAndTestHeuristics": "Able to formulate, test and suggest new ranking heuristics for use by discovery provider nodes",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "liveStreamingProvider": {
+      "title": "Live Streaming Provider",
+      "overview": "The platform supports live video, allowing publisher to distribute content as it is created. The live streaming providers are responsible for directly, or indirectly from peer providers, taking a (transcoded) stream from the source publisher, and relaying it to end users.",
+      "responsibilities": {
+        "runAndMaintainLivestreamingNodes": "Run and maintain live streaming nodes that deliver large volumes of upstream data to a large number of simultaneous end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with large amount of upstream bandwidth capacity.",
+        "locatedWithinBounds": "Located within certain bounds to designated geographic areas, in order to limit latency",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "builder": {
+      "title": "Builder",
+      "overview": "The platform runtime, tools, infrastructure software and user facing applications are all meant to evolve over time. A diverse set of contributors are required to facilitate this, including <0/><0/> <1> <0><0>Developers:</0> Software developers, Data scientists, DevOps and QA </0><0><0>Designers:</0> Web, Mobile, UX/UI, Branding and Visual Design </0> <0><0>Product Managers:</0> Digital Product Managers, Product Owners and Analysts </0> </0> <0 /> All of these contributors are collectively referred to as Builders. Anyone can contribute in the same mode as any of these possible contributor functions, as all the platform source assets are open source and developed in the open. Being a Builder means that one has some scope of responsibility in ongoing efforts, and that one has some predefined reward scheme associated with this responsibility.",
+      "responsibilities": {
+        "collaborate": "Collaborate with almost every other kind of platform member to maintain and improve the platform"
+      },
+      "requirements": {
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure and function",
+        "specificContributingSkills": "Have specific skills required for contributing in the given way",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "communicationModerator": {
+      "title": "Communication Moderator",
+      "overview": "The platform will have multiple ways of facilitating easy and secure public, and private, communication and information sharing among members. In particular, there will be both a forum and messaging capability built in to the platform. But in order for these spaces to be effective communication modes, some moderation will be required. Communication moderators are involved with policing this activity.",
+      "responsibilities": {
+        "monitorCommuncationChannels": "Monitor and supervise public communication channels for compliance with usage policies as decided through the governance system",
+        "communicateWithUsers": "Communicate with end users about any possible violations and sanctions",
+        "collaborate": "Collaborate to come up with new policies as circumstances change"
+      },
+      "requirements": {
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure and function",
+        "goodCommunicator": "Clear written communicator, ideally with good command of more than one language",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    }
+  }
+}

--- a/src/locales/es/rome.json
+++ b/src/locales/es/rome.json
@@ -1,0 +1,59 @@
+{
+  "rome": {
+    "siteMetadata": {
+      "description": "Explore the Rome testnet"
+    },
+    "hero": {
+      "title": "Rome Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY CONSTANTINOPLE ON"
+    },
+    "modal": {
+      "title": "Rome",
+      "text": "<0>The Roman empire left many landmarks.</0> Their architecture and engineering skills was unparalleled during their might. The concept of aqueducts was not devised by the Romans, but their beauty and extent is."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "No specifications were published for Rome."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "contentDirectory": {
+          "title": "Build a dynamic, flexible and user friendly content directory",
+          "text": "The Rome testnet is built around the introduction of a new content directory, that can be added to, modified and improved without requiring runtime upgrades. All key results and goals are derived from this."
+        },
+        "content": {
+          "title": "Populate the content directory with a variety of content",
+          "text": "Rome introduces a Content Directory system that is both built to last, yet still meant to be continuously improved on. We will pay for Content Creators to upload a variety of content and we hope to learn a lot from the results."
+        },
+        "contentCurator": {
+          "title": "Introduce the new Content Curator role",
+          "text": "With a new Content Directory, and incentives to upload content, we need monitoring. The Content Curators will require staking, and will be paid in both testnet tokens and Monero."
+        },
+        "contentCreator": {
+          "title": "Add Content Creator profiles",
+          "text": "Without Content Creators, there won't be any content. Granted, adding another level on top of the membership requirement may seem like a hurdle, but it will allow users to upload with multiple profiles."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Rome Network"
+    },
+    "map": {
+      "title": "Rome",
+      "text": "<0>Rome was the capital of the great Roman Empire during its peak.</0> As with previous testnet names, the Roman Empire and Rome was another important step in the rise of democracy, the rule of law, and modern governance structures.<1/><1/><2><0/> Explore current testnet</2>"
+    }
+  }
+}

--- a/src/locales/es/sparta.json
+++ b/src/locales/es/sparta.json
@@ -1,0 +1,41 @@
+{
+  "sparta": {
+    "siteMetadata": {
+      "description": "Explore the Sparta testnet"
+    },
+    "hero": {
+      "title": "Sparta Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "NETWORK DOWN",
+      "markdown": "\n ### FAILURE IDENTIFIED\n\n  On Friday the 29th of March, the Sparta network went down due to a [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) that we had not pulled down before release.\n\n  More details can be found in this [blog post](https://blog.joystream.org/sparta-sacked/)."
+    },
+    "modal": {
+      "title": "Helmet of Sparta",
+      "text": "<0>The Spartan army helmet</0> represents what Sparta is most known for today, their military might. For it's time, it was also known for its advanced governance system."
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our release OKR.",
+      "goals": {
+        "blockchain": {
+          "title": "Build and release a blockchain with a working Council",
+          "text": "As a \"user governed media platform\", allowing users to elect <0>Council Members</0> to represent their interest in day-to-day operations was a major goal for us."
+        },
+        "bugs": {
+          "title": "Keep the quantity of more or less critical bugs at an acceptable level",
+          "text": "As demonstrated by the fact that the network crashed, we did not reach our goals in this case."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Sparta testnet"
+    },
+    "map": {
+      "title": "The city of Sparta",
+      "text": "<0>Sparta was a prominent city-state in Ancient Greece.</0> In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution. <1/><1/> We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law, however draconian by modern standard."
+    }
+  }
+}

--- a/src/locales/es/sumer.json
+++ b/src/locales/es/sumer.json
@@ -1,0 +1,47 @@
+{
+  "sumer": {
+    "siteMetadata": {
+      "description": "Explore the Sumer testnet"
+    },
+    "hero": {
+      "title": "Sumer Network",
+      "text": "Among other changes, the Sumer testnet release offers major improvements to content uploads through our playback app."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Sumer testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Sumer testnet.",
+      "goals": {
+        "contentPublishing": {
+          "title": "Enable content publishing from playback interface",
+          "text": "Sumer introduces the ability to create and manage channels and videos in the Joystream Player, replacing the cumbersome and technically challenging CLI-dependent process required on the Antioch testnet."
+        },
+        "deployingNewContentDirectory": {
+          "title": "Deploying the new content directory",
+          "text": "As part of Sumer we will be introducing a simple native runtime module. This is because technical complexities and tradeoffs associated with the previous iterations of the content directory were not acceptable."
+        },
+        "enableBuilderRole": {
+          "title": "Enable builder/platform operations role",
+          "text": "We are introducing a new working group focused on platform operations. Originally, we had also planned to enable the new \"Gateway\" role, though this is no longer in the scope of the Sumer release."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Sumer Network"
+    },
+    "map": {
+      "title": "Sumer",
+      "text": "<0>Sumer is the earliest known civilization in the historical region of southern Mesopotamia</0>, emerging during the Chalcolithic and early Bronze Ages between the sixth and fifth millennium BC.<1/><1/>Living along the valleys of the Tigris and Euphrates, Sumerian farmers grew an abundance of grain and other crops, the surplus from which enabled them to form urban settlements. The region is thought to be where the earliest forms of writing emerged.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/es/token.json
+++ b/src/locales/es/token.json
@@ -1,0 +1,67 @@
+{
+  "token": {
+    "siteMetadata": {
+      "title": "Token",
+      "description": "Participants on our testnets can now earn Joystream Testnet Tokens (tJOYs) backed by fiat currency."
+    },
+    "hero": {
+      "title": "Understanding the tJOY token",
+      "text": "Participants on our testnets can now earn Joystream Testnet Tokens (tJOYs) backed by fiat currency.",
+      "tokenStats": {
+        "title": "Token in numbers",
+        "exchangeRate": "Exchange Rate",
+        "backingValue": "Backing Value",
+        "supply": "Supply"
+      }
+    },
+    "faq": {
+      "title": "Testnet Token Information",
+      "whatIsTJoy": {
+        "title": "What is tJOY?",
+        "text": "tJOY (testJOY) is the currency used on Joystream incentivized testnets."
+      },
+      "tJoyValueOrigin": {
+        "title": "Where does the value of tJOY come from?",
+        "text": "Jsgenesis, the team behind the Joystream project, have linked the total supply of tJOYs to a corresponding pool of fiat currency (USD) held by the company. All testnet participants can redeem their tJOY for USD at any time."
+      },
+      "purposeOfTJoy": {
+        "title": "What is the purpose of tJOY?",
+        "text": "tJOY can be used on our testnets in the same ways that future users of the Joystream platform will be able to use the mainnet JOY token. The three principal functions of tJOY are in staking, governance and for payment.<0/><0/> For example, to participate in testnet roles, users may need to stake tJOY. To create governance proposals and vote for Council Members, tJOY is also required. Finally, on the testnet, bounties and KPIs require tJOYs for paying effective contributors."
+      },
+      "whereCanTJoyBeObtained": {
+        "title": "Where can I get tJOY?",
+        "text": "There are many opportunities to obtain tJOY. Smaller amounts can be requested in our community channels (including our Discord server and on-chain forum), while larger sums can be accumulated by participating in bounties, competitions and other events."
+      },
+      "linkBetweenTJoyAndFutureToken": {
+        "title": "Is there any link between tJOY and the future mainnet token?",
+        "text": "There is no direct link between tJOY and mainnet JOY. We are using tJOY to simulate the real economic incentives present on mainnet to aid the platform's development and facilitate the growth and education of our community in preparation of the transition from testnet to mainnet."
+      },
+      "howToCashout": {
+        "title": "How do I cashout tJOY to USD?",
+        "text": "We use Bitcoin Cash (BCH) as a payment rail on our testnets. You can cashout tJOY by making a transfer to the dedicated burn address: <0>5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMaeKQu</0> Before doing this, you should set the <0>memo</0> of the key from which the transfer is made to your BCH address. At the moment of the transfer, the BCH to USD exchange rate is locked. <1/><1/>More information on payouts can be found <2>here</2>."
+      },
+      "howToEarn": {
+        "title": "How can I earn mainnet JOY?",
+        "text": "Currently, the only way to secure an allocation of mainnet JOY is through high-quality contributions to the platform and community via our <0>Founding Member Program</0>."
+      },
+      "TJoyWorth": {
+        "title": "How much is tJOY worth?",
+        "text": "You can check the live exchange rate (tJOY->USD) on this page (see above)."
+      }
+    },
+    "cashouts": {
+      "title": "Pending cashouts",
+      "subtitle": "Tokens sent to Jsgenesis in this exchange are burned, hence the final price of the token is unaffected by such an exchange.",
+      "cashout": {
+        "address": "Source address",
+        "tokensTransferred": "Tokens transferred",
+        "usdValue": "USD Value",
+        "blockNumber": "Block Number",
+        "exchangeNumber": "Exchange #"
+      }
+    },
+    "cta": {
+      "title": "Join our Discord and change the online video industry"
+    }
+  }
+}

--- a/src/locales/fr/about.json
+++ b/src/locales/fr/about.json
@@ -1,0 +1,51 @@
+{
+  "about": {
+    "general": {
+      "roles": {
+        "blockchain": "Blockchain Engineer",
+        "frontEnd": "Front-End Engineer",
+        "design": "Designer",
+        "growth": "Growth",
+        "core": "Core",
+        "ceo": "CEO",
+        "cto": "CTO",
+        "cooAndGrowth": "COO & Growth",
+        "all": "All",
+        "allMembers": "All members"
+      }
+    },
+    "siteMetadata": {
+      "title": "About us",
+      "description": "We don't just offer great compensation and flexibility, but the perfect mission, team and timing for you to build something that changes everything."
+    },
+    "hero": {
+      "title": "We are building Joystream to set it free",
+      "subtitle": "Jsgenesis is the core team building Joystream the platform and open-source blockchain."
+    },
+    "ourTeam": {
+      "title": "Our team",
+      "subtitle": "We come from different continents, but share a passion for open source, blockchain technology, distributed systems, privacy and building a new internet based on accountable and forkable institutions.",
+      "moreMembers": "Load more team members"
+    },
+    "investors": {
+      "title": "Our investors"
+    },
+    "positions": {
+      "title": "Open positions",
+      "available": "3 jobs available",
+      "join": "Join",
+      "roles": {
+        "frontEnd": "Front-end Developer",
+        "blockchain": "Blockchain Developer",
+        "designer": "UI/UX Design Lead"
+      },
+      "location": "Oslo, Europe, Remote",
+      "employmentType": "Full time",
+      "salary": {
+        "frontEnd": "$80K-$130K",
+        "blockchain": "$100K-$140K",
+        "designer": "$100K-$140K"
+      }
+    }
+  }
+}

--- a/src/locales/fr/acropolis.json
+++ b/src/locales/fr/acropolis.json
@@ -1,0 +1,59 @@
+{
+  "acropolis": {
+    "siteMetadata": {
+      "description": "Explore the Acropolis testnet"
+    },
+    "hero": {
+      "title": "Acropolis Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ROME ON"
+    },
+    "modal": {
+      "title": "The Acropolis of Athens",
+      "text": "<0>Known for its great architecture, Acropolis'</0> perhaps most famous building is the Parthenon. It was built to celebrate their victory over Persian invaders, and is today seen as a symbol for democracy and western civilization."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "Read the specs of the newly implemented features of Acropolis."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "forum": {
+          "title": "Build and release an on-chain forum",
+          "text": "The final platform will have built in multiple ways of facilitating easy and secure public, and private, communication and information sharing among members. The forum is the first step allowing the platform members to communicate, share ideas and discuss."
+        },
+        "storageNode": {
+          "title": "Rebuild and release the storage node",
+          "text": "Where the old storage node had some bugs making it unable to sync between clients and required a hardcoded liaison, the new storage node is working as intended with no hierarchy or privileges."
+        },
+        "storageProviders": {
+          "title": "Ensure high uptime of storage providers",
+          "text": "Both content creators and consumers user experience depends on various metrics, but perhaps the most important is that the storage node they connect to responds to their request. Whether or not this goal is achieved depends on both the reliability of the software, a good reporting system and corrective actions from multiple parties."
+        },
+        "tranches": {
+          "title": "Build the storage node with \"tranches\"",
+          "text": "Although the content directory is currently small, at some point it's not feasible to expect all storage providers to have full replication of all the content. Tranches would allow storage providers to select a subset of the content directory, suitable to their capabilities."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Acropolis testnet"
+    },
+    "map": {
+      "title": "Acropolis of Athens",
+      "text": "<0>The Acropolis is a citadel on a hill in the heart of Athens.</0> It was also at the heart of Ancient Greece, a powerful civilization and empire. Acropolis is famous for its ancient buildings, architecture, historical significance and is one of the main tourist attractions of Athens. It is on UNESCOs list \"World Heritage Sites\".<1/><1/> We chose the name as we had to scale back our ambitions for the next testnet after some issues with the release of Athens. Thus, Acropolis can be considered a sub-release, despite including some new features not intended for Athens. <1/><1/> <2><0/> Explore previous testnet</2>"
+    }
+  }
+}

--- a/src/locales/fr/alexandria.json
+++ b/src/locales/fr/alexandria.json
@@ -1,0 +1,55 @@
+{
+  "alexandria": {
+    "siteMetadata": {
+      "description": "Explore the Alexandria testnet"
+    },
+    "hero": {
+      "title": "Alexandria Network",
+      "text": "The Alexandria release focuses on important technical updates which will facilitate more efficient future development.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY BABYLON ON"
+    },
+    "modal": {
+      "title": "Alexandria",
+      "text": "There are two sphinxes at the Pompey's Pillar site in Alexandria, Egypt. The sphinxes and associated column are one of Alexandria's most important ancient monuments. <0/><0/> The Alexandria sphinxes should not be confused with the more well-known Great Sphinx located at Giza, just under 200 kilometers south-east of Alexandria."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Alexandria testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Alexandria testnet.",
+      "goals": {
+        "membershipModule": {
+          "title": "Cleaning up the membership module",
+          "text": "Tackling technical debt in the membership module and making it possible to transition to using memberships as the only core actor identifier in the system in future releases."
+        },
+        "substrateVersion": {
+          "title": "Start using Substrate v2.0.0 RC4",
+          "text": "We are transitioning to a new version of Substrate in order to stay up to date with a broad range of enhancements, and to limit how far behind we allow our growing codebase to become."
+        },
+        "networkTesting": {
+          "title": "Enhancing our network testing",
+          "text": "Further maturing our network testing infrastructure to get one step closer to true end-to-end builds that secure an increasingly shorter development cycle."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Alexandria Network"
+    },
+    "map": {
+      "title": "Alexandria",
+      "text": "<0>Alexandria was founded in approximately 331 BC by Alexander the Great.</0> The city was best known for the Lighthouse of Alexandria, one of the Seven Wonders of the Ancient World, as well as its colossal Great Library.<1/><1/> Alexandria was the intellectual and cultural center of the ancient Mediterranean world for much of the Hellenistic age and late antiquity. It was at one time the largest city in the ancient world before being eventually overtaken by Rome.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/fr/antioch.json
+++ b/src/locales/fr/antioch.json
@@ -1,0 +1,42 @@
+{
+  "antioch": {
+    "siteMetadata": {
+      "description": "Explore the Antioch testnet"
+    },
+    "hero": {
+      "title": "Antioch Network",
+      "text": "The Antioch release seeks to patch a chain split bug which unfortunately sabotaged the previous testnet."
+    },
+    "heroCard": {
+      "title": "REPLACED BY SUMER ON"
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Antioch testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Antioch testnet.",
+      "goals": {
+        "substrateVersion": {
+          "title": "Upgrade Substrate Version",
+          "text": "<0>To patch the chain split issue encountered on Babylon we need to update the version of Substrate our network is built on from <1>v2-rc4</1> to <1>v2.0.1</1></0>"
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Antioch Network"
+    },
+    "map": {
+      "title": "Antioch",
+      "text": "<0>Antioch was an ancient Greek city on the eastern side of the Orontes River.</0> The city's position benefited its occupants greatly, particularly on account of such features as the spice trade, the Silk Road, and the Royal Road.<1/><1/>At its height it rivaled Alexandria as the chief city of the Near East. Many also consider the city to be \"the cradle of Christianity\".<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/fr/athens.json
+++ b/src/locales/fr/athens.json
@@ -1,0 +1,59 @@
+{
+  "athens": {
+    "siteMetadata": {
+      "description": "Explore the Athens testnet"
+    },
+    "hero": {
+      "title": "Athens Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "text": "AFTER LAUNCHING 17 / 04 / 19 <0/> THE NETWORK WAS UPGRADED TO <1>ACROPOLIS</1> ON"
+    },
+    "modal": {
+      "title": "Owl of Athena",
+      "text": "<0>In Greek mythology, a little owl (Athene noctua)</0> traditionally represents or accompanies Athena, the virgin goddess of wisdom. Because of such association, the bird — often referred to as the \"owl of Athena\" — has been used as a symbol of knowledge, wisdom, perspicacity and erudition throughout the Western world."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "No specifications was published for Athens."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "media": {
+          "title": "Enable media on the platform",
+          "text": "As a \"user governed media platform\", allowing users to upload and consume and content was a major goal for us."
+        },
+        "memberships": {
+          "title": "Introduce platform memberships",
+          "text": "Although we are building an open blockchain in the sense that users are free to send tokens as they like, the Joystream experience is about having the platform users own, operate and govern the platform. We are agnostic on exactly what parts of the platform will be reserved for members, some actions will require and extra level of screening and accountability."
+        },
+        "storageNode": {
+          "title": "Build and release the storage node",
+          "text": "Although a storage node was built and used to host and distribute the platform content, it had some bugs making it unable to sync between clients and required a hardcoded liaison."
+        },
+        "runtimeUpgrade": {
+          "title": "Upgrade the runtime through a Council vote",
+          "text": "The intention was for Jsgenesis to create a proposal for a <0>runtime upgrade</0> and have the Council vote on it. If the Council reached quorum, the consensus rules of the system would automatically get upgraded in flight. Unfortunately, the <1>Sparta network crashed</1> before we reached this stage, and had to start Athens as a new chain with a new genesis block."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Athens testnet"
+    },
+    "map": {
+      "title": "The city of Athens",
+      "text": "<0>Athens is the capital of Greece.</0> It was also at the heart of Ancient Greece, a powerful civilisation and empire. The city is still dominated by 5th-century BC landmarks, including the Acropolis, a hilltop citadel topped with ancient buildings like the colonnaded Parthenon temple. <1/><1/> We chose the name Athens as, like our previous testnets, Mesopotamia and Sparta, the ancient Athens' historical significance in the development towards modern democracy and the rule of law. <1/><1/> <2> <0/> Explore previous testnet</2>"
+    }
+  }
+}

--- a/src/locales/fr/babylon.json
+++ b/src/locales/fr/babylon.json
@@ -1,0 +1,55 @@
+{
+  "babylon": {
+    "siteMetadata": {
+      "description": "Explore the Babylon testnet"
+    },
+    "hero": {
+      "title": "Babylon Network",
+      "text": "The Babylon release offers improvements which greatly enhance the video publishing and consumption experience.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ANTIOCH ON"
+    },
+    "modal": {
+      "title": "Tower of Babel",
+      "text": "The Tower of Babel story is an origin myth meant to explain why the world's peoples speak different languages.<0/><0/>According to the story, a united human race in the generations following the Great Flood, speaking a single language and migrating eastward, comes to the land of Shinar. There they agree to build a city and a tower tall enough to reach heaven.<0/><0/> God, observing their city and tower, confounds their speech so that they can no longer understand each other, and scatters them around the world."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Babylon testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Babylon testnet.",
+      "goals": {
+        "atlas": {
+          "title": "Launch Atlas 0.1",
+          "text": "This will be the initial release of our content consumption client, aiming to be considerably more effective than the current Pioneer media experience."
+        },
+        "contentDirectory": {
+          "title": "Deploy a new content directory and corresponding working group",
+          "text": "We will be modifying the content directory to allow for a new data model for content, supported by new schemas. We will also make some associated improvements to the Content Curator Working Group."
+        },
+        "hydraNode": {
+          "title": "Deploy first self-hosted Joystream Hydra node only supporting content directory",
+          "text": "Further work on our Hydra framework is required in order to support the new content directory."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Babylon Network"
+    },
+    "map": {
+      "title": "Babylon",
+      "text": "<0>Babylon was the capital city of Babylonia, a kingdom in ancient Mesopotamia, almost 4000 years ago.</0> It was built along the left and right banks of the Euphrates river with steep embankments to contain the river's seasonal floods. <1/><1/> The city is considered to be of great historical and cultural importance. The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World and Babylon was also purported to be the site of the Tower of Babel.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/fr/brand.json
+++ b/src/locales/fr/brand.json
@@ -1,0 +1,198 @@
+{
+  "brand": {
+    "siteMetadata": {
+      "title": "Joystream Brand Guide"
+    },
+    "assets": {
+      "logo": "Logo",
+      "logoIcons": "Logo Icons",
+      "descriptiveIcons": "Descriptive Icons",
+      "illustrations": "Illustrations",
+      "systemIcons": "System Icons",
+      "typography": "Typography",
+      "blogPostCovers": "Blog Post Covers",
+      "displayTitle": {
+        "logoPack": "Logo Pack"
+      },
+      "files": "files"
+    },
+    "guides": {
+      "general": {
+        "logo": "Logo",
+        "overview": "Overview",
+        "logomark": "Logomark",
+        "construction": "Construction",
+        "useCases": "Use Cases",
+        "socialIcons": "Social Icons",
+        "forbiddenUses": "Forbidden Uses",
+        "colorPalettes": "Color Palettes",
+        "primaryColors": "Primary Colors",
+        "supportivePallet": "Supportive Pallet",
+        "secondaryPallet": "Secondary Pallet",
+        "iconography": "Iconography",
+        "descriptiveIcons": "Descriptive Icons",
+        "systemIcons": "System Icons",
+        "illustrations": "Illustrations",
+        "patterns": "Patterns",
+        "typography": "Typography",
+        "photography": "Photography",
+        "motion": "Motion",
+        "back": "Back",
+        "more": "More"
+      },
+      "logo": {
+        "experimentation": "Our brand should promote a feeling of experimentation, excitement and building something ethical and dynamic.",
+        "conceptIterations": "Before we agreed on a final logo concept we went through multiple iterations of various concepts. We explored various ideas in depth before settling on the final logo concept."
+      },
+      "logomarkConstruction": {
+        "title": "01. Logomark Construction",
+        "simplePrinciples": "In the end we came up with a logomark that combines several simple principles which translate well to the voice of the brand.",
+        "combination": "Our logomark is a combination of the letter J (to represent the name Joystream) and three parallel stripes that are a representation of streaming data and the flow of information and technology.",
+        "image": {
+          "logomarkDescription": "Logomark's exclusion zone is equal to the blue square height (marked as 5a in the diagram)."
+        }
+      },
+      "logoConstruction": {
+        "title": "02. Logo Construction",
+        "combination": "The Joystream logo is a combination of the logomark and dedicated typography that was designed to be the best link between the logomark and what Joystream stands for. It is firm and technical but shows plasticity and sense of a structure.",
+        "horizontalLockup": "Horizontal Lockup",
+        "verticalLockup": "Vertical Lockup"
+      },
+      "logoUseCases": {
+        "title": "03. Logo Use Cases",
+        "originalForm": "The Joystream logo is primarly used in its original form on white backgrounds but it can also be used in its complimentary forms if necessary. Examples show such use cases below.",
+        "safeUse": "The smallest safe use",
+        "visualPresentation": "In order to ensure the best visual presentation of the logo, it is best offered in sizes between <0>200 and 500+px</0> width on digital devices.",
+        "horizontalNarrow": "The Joystream logo should never be narrower than 100px in digital or 20mm in print horisontal lockup.",
+        "verticalNarrow": "Vertical lockup should never be narrower than 70px in digital or 15mm in print."
+      },
+      "logoSocialIcons": {
+        "title": "04. Social Icons",
+        "icon": "In cases when the Joystream brand has already been established we can simply use the icon on its own. While the icon can exist without the wordmark, the wordmark should never exist without the icon."
+      },
+      "logoForbiddenUses": {
+        "title": "05. Forbidden uses of the logo",
+        "rules": "The logotype and the icon must follow certain rules and there are general cases of use that should be avoided at all costs! In order to preserve the brand voice remember to avoid examples such as the following:"
+      },
+      "colorOverview": {
+        "combine": "Our brand colors combine three primary colors: black, white and blue. They define the mood and present brand values including:",
+        "example": "Stability, Trust, Freedom, Responsibility, Loyalty, Wisdom, Confidence and Intelligence"
+      },
+      "primaryColors": {
+        "title": "01. Primary Colors",
+        "blackAndBlue": "Our primarly used colors are black and Joystream blue, a distinctive color that helps to put focus and draw attention. The color white can be deployed in order to calm, provide clarity and offer improved readability.",
+        "blueGrey": "One additional color to combine with the three primary colors is blue tinted grey, its purpose is comparable to that of white but it also gives a good amount of contrast to the existing white elements where necessary."
+      },
+      "supportiveColors": {
+        "title": "02. Supportive Color Palette",
+        "purpose": "Our supportive palette serves the purpose of convenience and usability. This pallete provides a comprehensive range of different shades of primary colors and can be utilised in many different ways depending on requirements."
+      },
+      "secondaryColors": {
+        "title": "03. Secondary Color Palette",
+        "states": "These are further colours that can represent certain states of the network, they can stand for an error, success, warning and more."
+      },
+      "iconsOverview": {
+        "text": "Icons can be divided into two groups with different purposes. Descriptive icons are a substitute for illustrations and system icons are a purely functional part of the interface.",
+        "typeDescriptive": "01. Descriptive",
+        "typeSystem": "02. System"
+      },
+      "descriptiveIcons": {
+        "title": "01. Descriptive Icons",
+        "comprehensiveStyle": "Joystream iconography is a custom, comprehensive icon style that helps in explaining certain complex topics in a simple, digestable manner.",
+        "symbolic": "They are not always very direct and often carry a symbolic meaning but they help to emphasize important elements.",
+        "characteristicFeatures": "Characteristic features of the descriptive icons include paralell striped fills. They are a translation of logo stripes and represent shadows.",
+        "angle": "Lines have an angle of 45° they should have 2px girth and 8px space between them at 100% scale.",
+        "outlines": "Icons are drawn using outlines of 12px width at 100% scale, they have square linecaps and can have various sizes depending on the composition.",
+        "fit": "Icons at 100% scale should fit into a box of 800x500px."
+      },
+      "systemIcons": {
+        "title": "02. System Icons",
+        "basicStyle": "System icons in their basic style combine two colors: black and Joystream Blue. Their purpose is to represent certain actions on the website or platform. They are readable even in small sizes down to 18x18px.",
+        "strokes": "System Icons are drawn using 2px strokes with square linecaps on a 24px grid frame.",
+        "subtleAccents": "Where possible, icons should have subtle blue accents representing no greater than 40% of the whole.",
+        "types": "Types of system icons",
+        "fourTypes": {
+          "text": "We distinguish four types of system icons and they should be used preferably in their basic style but can be used interchangeably where neccessary.",
+          "basic": "Basic style",
+          "blue": "Blue outlines",
+          "white": "White outlines",
+          "full": "Full style"
+        }
+      },
+      "illustrations": {
+        "overview": "Joystream Illustrations are symbolic representation of important concepts within the Joystream project. These might include a a new testnet, a particular role on the network or any other equally significant subject.",
+        "complex": "They can be quite visualy complex despite using only three colors and no gradients.",
+        "patterns": "Illustrations will often be combined with patterns and in the case of putting them on a blue background, the outline of the illustration can be changed to Joystream Blue in order to create a good color balance between patterns and the background.",
+        "distinctive": "Illustrations should be simple enough to be distinctive even in smaller resolutions down to 300x300px.",
+        "adequateDetail": "The amount of detail should be adequate to what the illustration represents, in most cases they should be deployed at sizes no smaller than 500x500px."
+      },
+      "patterns": {
+        "translation": "Patterns are close translation of the logomark (J) into variants of geometrical shapes representing the flow of information, technology and Joystream's experimental brand personality.",
+        "supportTool": "They were introduced as a support tool to make certain elements stand-out, to build mood and as an inherent element of the visual identity of the brand.",
+        "sixPieces": "Patterns visually consist of six different pieces that can be rotated by 90 degrees in any direction and should always have the dimensions of a perfect square.",
+        "oneCommonVertex": "They should also have at least one common vertex when they touch. They do not always have to touch and when they don’t, space between pieces should always be equal to its’ width/height or the value multiplied.",
+        "howToUse": "How to use patterns",
+        "oneOfFive": "Patterns can use one of five different colors depending on what background is used beneath and what their main purpose is in a given situation.",
+        "density": "Depending on the situation these can be used more or less densely.",
+        "inUse": "Patterns in use - examples"
+      },
+      "typography": {
+        "overview": "Our typefaces are simple, comprehensive and modern. This is a reflection of our brand and our voice. We chose the appropriate typeface weights from PX Grotesk (regular, bold) and Inter family for specific touchpoints and to create clear hierarchies of information and messages.",
+        "backup": "If either two typefaces are impossible to use please choose Arial Regular. This may be required across PC operating systems or electronic internal documents or in diferent offices worldwide. Don’t use Arial for any print materials.",
+        "sample": "The following is a sample of an ideal font stack using PX Grotesk for headlines and larger pull quote text and Inter UI for paragraph and call-to-action text."
+      },
+      "photography": {
+        "overview": "Photographs should be relevant to the topic they are describing but they shouldn’t be limited only to technology. Joystream is much more than just technology; it is unifying, fresh and joyful. Imagery should convey this mood to users.",
+        "howToUse": "How to use photography",
+        "variety": "Since Joystream is a unique and experimental project it provides a wide variety of the topics which might be  associated with it in terms of photography. It is highly technical especially now when we are in the community building phase, so good deal of the photographs will be tech related.",
+        "consistency": "One way to make sure the photographs are consistent is to use them in dual tones deriving from branding colors. For that purpose we can use a handy tool to consistently change images to dual tones as described below.",
+        "consistentDuotones": "The link below allows you to create consistent duotones with any photography after inputing the proper two Joystream colours.",
+        "mood": "The mood that photos convey is extremely important. It should by all means give a feel of building trust, community and joy. Photographs should show good amount of diversity as it is meant to be for an extremely wide variety of users. They don’t have to be used in dual tones but it is best if they are not \"screaming\" with colours.",
+        "inUse": "Photography in use - examples"
+      },
+      "motion": {
+        "subtitle": "Joystream is an experimental and exciting platform and its motion should be too.",
+        "rules": "General rules for motion can be described with a few simple principles: smooth transitions, dynamic but fluid motion and good amount of easing at the keyframes. This combination should provide a consistent and flexible animation style to cover most of the use cases.",
+        "notLimiting": "Guides should be by no means limiting, they should only serve the purpose of providing consistency for animations."
+      }
+    },
+    "story": {
+      "header": {
+        "title": "Joystream Brand Story",
+        "description": "Joystream offers a modern, experimental solution to the problem of accountable governance in digital media. <0>Our objective is to build a user-governed video platform with a strong sense of community and freedom.</0>",
+        "buttonText": "Manifesto"
+      },
+      "website": {
+        "title": "The Website",
+        "linkText": "Visit the Website"
+      },
+      "description": {
+        "header": "Our brand identity consists of few key visual elements: our logo, typeface, illustrations, patterns, colour palette and iconography.",
+        "meaningfulRole": "Each of these elements has a meaningful role in brand identity as established in the guidelines. But combining all of these components builds much more than just a visual experience.",
+        "powerfulTool": "Joystream branding is a powerful tool for communication with all of its users throughout their whole experience.",
+        "experimental": "Fundamentally, our effort is an experimental one; we do not have all the answers, and we want to be honest about that in our communication.",
+        "empowering": "We are not promising cheaper, faster or nicer, like one typically would when selling a consumer widget or service. Instead we have hope that we can build something more empowering and accountable through our process of experimentation.",
+        "governance": "Lastly, at the core of our vision is governance, so what we are building is never finished; we are only constructing the first piece. It is a dynamic effort we hope communities will carry forward in amazing ways, we are just providing the first set of tools.",
+        "footer": "For the reasons outlined above, our brand should carry this feeling of experimentation, excitement and building something ethical and dynamic."
+      },
+      "logo": {
+        "title": "We want to free the media, inspire people and connect them using platform",
+        "uniqueness": "Creating the Joystream brand proved to be challenging due to its uniqueness and the fact that it is continually evolving.",
+        "requirements": "Not only did we have to take into account a very wide and diverse user base but also we had to create a brand that will be futureproof and flexible enough to cover both the existing and upcoming requirements of the project.",
+        "branding": "Joystream branding itself is quite metaphoric and symbolic, often referring to symbolism of ancient cities, culture, arts and philosophies.",
+        "challenge": "The challenge was to combine it with very modern and complex technologies."
+      },
+      "explanation": {
+        "title": "Explaining the Brand",
+        "balance": "Our new branding is about finding good balance between a very simplistic tone of communication with the symbolism and complexity of modern world problems and technologies.",
+        "patterns": "Our branding uses mosaic, geometrical patterns and shapes combined with explicit colours and symbolic  illustrations.",
+        "style": "We also deploy descriptive icons in combination with simple glyph style system icons and an experimental  illustration style."
+      }
+    },
+    "button": {
+      "text": {
+        "downloadLogo": "Download Logo"
+      }
+    }
+  }
+}

--- a/src/locales/fr/constantinople.json
+++ b/src/locales/fr/constantinople.json
@@ -1,0 +1,51 @@
+{
+  "constantinople": {
+    "siteMetadata": {
+      "description": "Explore the Constantinople testnet"
+    },
+    "hero": {
+      "title": "Constantinople Network",
+      "text": "The Constantinople testnet introduces an improved proposals system and fiat-backed token model for participant compensation.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ALEXANDRIA ON"
+    },
+    "modal": {
+      "title": "Constantinople",
+      "text": "The Column of Constantine, also known as the Burnt Stone or the Burnt Pillar, is a Roman monumental column constructed on the orders of the Roman emperor Constantine the Great in 330 AD. It commemorates the declaration of Byzantium as the new capital city of the Roman Empire."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Constantinople testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Constantinople testnet.",
+      "goals": {
+        "proposalSystem": {
+          "title": "Launch a new proposal system",
+          "text": "The constantinople testnet is built around the introduction of a proposal system that strengthens the governance structure of the platform, shifting the day to day responsibility of monitoring the network and allocating resources to voters and the council."
+        },
+        "tokenModel": {
+          "title": "Introduce a fiat-backed token model",
+          "text": "Constantinople introduces a new incentive structure, with a fiat (USD) pool backing the testnet tokens, setting up a more realistic economic system for the platform."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Constantinople Network"
+    },
+    "map": {
+      "title": "Constantinople",
+      "text": "<0>Constantinople was the capital city of the Eastern Roman Empire during the fourth century.</0> It was famed for its massive and complex defences as well as its architectural masterpieces and opulent aristocratic palaces. As was the case with the city, we hope our Constantinople testnet will be a worthy successor to Rome.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/fr/dashboard.json
+++ b/src/locales/fr/dashboard.json
@@ -1,0 +1,17 @@
+{
+    "dashboard" : {
+        "siteMetadata" : {
+            "title" : "Live Dashboard",
+            "description" : "Data compiled from current Pioneer and Atlas instances and visualized through charts."
+        },
+        "title" : "Joystream Dashboard",
+        "subtitles" : {
+            "videos" : "Videos",
+            "channels" : "Channels",
+            "users" : "Users",
+            "posts" : "Posts",
+            "threads" : "Threads"
+        },
+        "amount" : "Amount"
+    }
+}

--- a/src/locales/fr/founding-members.json
+++ b/src/locales/fr/founding-members.json
@@ -1,0 +1,171 @@
+{
+  "foundingMembers": {
+    "general": {
+      "foundingMembers": "Founding Members",
+      "nonFoundingMembers": "Non-Founding Members",
+      "directScore": "Direct Score",
+      "referralScore": "Referral Score",
+      "totalScore": "Total Score",
+      "inducted": "Inducted",
+      "member": "Member",
+      "backButton": "Back to Program page",
+      "before": "Before",
+      "account": "Account",
+      "next": "Next",
+      "howItWorks": "How it works.",
+      "inputPlaceholder": "e.g. joedoe",
+      "inductionDate": "Induction Date",
+      "joinOurDiscord": "Join our Discord"
+    },
+    "scoringPeriod": {
+      "title": "Current scoring period",
+      "currentNumber": "Current period number",
+      "ends": "ENDS",
+      "endedOn": "ENDED ON",
+      "weeks": "WEEKS",
+      "days": "DAYS",
+      "hours": "HOURS",
+      "minutes": "MINUTES",
+      "submitSummary": "Submit Summary",
+      "periodAnnouncement": "Period Announcement",
+      "announcement": "Announcement"
+    },
+    "landing": {
+      "siteMetadata": {
+        "title": "Founding Members",
+        "description": "Information and data regarding the new Founding Members Program of the Joystream platform."
+      },
+      "hero": {
+        "title": "Joystream Founding Member Program",
+        "text": "Founding Members are highly effective project contributors awarded JOY tokens in the mainnet genesis block.",
+        "imageAlt": "founding members visual"
+      },
+      "list": {
+        "currentMembers": "Current founding members",
+        "newMembers": "New founding members",
+        "iconAlt": "icon of founding member"
+      },
+      "benefits": {
+        "title": "What is the Founding <0/> Member Program <0/> and why does it exist?",
+        "currentlyBuilding": "While Jsgenesis is the team currently building the technology behind the Joystream project, we will not be around forever, and we are instead entrusting the future operation of the Joystream DAO to our community members.",
+        "foundingMembers": "The Founding Member Program formally allocates JOY tokens among some of our highest quality community members in recognition of their contributions to the project and ensures that a sufficiently large, effective and motivated community of users is ready to occupy all the different roles required to run, evolve and grow the platform on mainnet.",
+        "benefits": "Benefits",
+        "benefitsAlternate": "Benefits of becoming a founding member",
+        "payout": {
+          "title": "Tokens",
+          "text": "allocated tokens in the genesis block of the Joystream mainnet as a result of high quality participation and recruiting other participants"
+        },
+        "membership": {
+          "title": "Membership Status",
+          "text": "special status membership assigned in genesis block, which will have a visually distinguished presentation in Pioneer and other products"
+        },
+        "avatar": {
+          "title": "Handcrafted Avatar",
+          "text": "receive a handcrafted premium membership avatar and be honoured on the official project website and social media leading up to mainnet"
+        },
+        "itemImageAlt": "benefit item"
+      },
+      "takePart": {
+        "title": "How to participate in the program",
+        "introduceYourself": {
+          "text": "Introduce yourself on Discord.",
+          "altText": "Introduce yourself in our Discord."
+        },
+        "contribute": {
+          "text": "Make contributions to the project.",
+          "contributions": "<0><0>training other participants</0><0>writing blog posts and documentation</0><0>creating and publishing new video content</0><0>participating in platform roles on the testnet</0><0>finding and reporting bugs and errors</0><0>completing official bounties</0><0>creative and design work</0></0>"
+        },
+        "report": "Regularly report your activity.",
+        "earnPoints": "Earn leaderboard points.",
+        "becomeFM": "Become a founding member!",
+        "buttonText": "Join Discord",
+        "excluded": "Countries that are excluded from that program: ",
+        "usFlagAlt": "us flag icon",
+        "tokensAlt": "two tokens"
+      },
+      "keyMetrics": {
+        "title": "Key metrics for the program",
+        "initialTokenPool": "size of initial token pool",
+        "numberOfFM": "number of founding members",
+        "numberOfCandidates": "number of founding member candidates",
+        "leaderboards": "Leaderboards",
+        "foundingMembersButton": "All Founding Member Scores",
+        "regularMembersButton": "All Regular Member Scores",
+        "fullProgramRules": "Read the full program rules"
+      },
+      "cta": {
+        "title": "Discuss the program",
+        "joinDiscord": "Begin your founding member journey by joining our Discord group and requesting your first testnet tokens.",
+        "askQuestions": "Here you can also ask question about many aspects of the program and find out the areas where you can contribute right away.",
+        "joinNow": "Join now",
+        "imageAlt": "founding members visual"
+      },
+      "disclaimer": {
+        "title": "Disclaimer",
+        "text": "This disclaimer applies to the webpage accessible at <0>www.joystream.org/token</0> as well as all other webpages, digital services or applications published by Jsgenesis (the “Company”). The disclaimer also applies to any material published by Company in any other format in connection with the JOY token (the “Token”). Publications made by Company and all information contained within them are not directed at or intended for use by any person resident or located in any jurisdiction where (1) the distribution of such information is contrary to the laws of such jurisdiction; or (2) such distribution is prohibited without obtaining the necessary licenses or authorizations by the relevant branch, subsidiary or affiliate office of Company and such licenses or authorizations have not been obtained. Company does not provide investment, legal or tax advice and nothing herein should be construed as being financial, legal, tax or other advice. Unless specifically stated otherwise, all price information is indicative only. No representation or warranty, either express or implied, is provided in relation to the accuracy, completeness or reliability of the materials, nor are they a complete statement of the securities, markets or developments referred to herein. The materials should not be regarded by recipients as a substitute for the exercise of their own judgment. All information and materials published, distributed or otherwise made available by Company in relation to Token are provided for informational purposes, for your non-commercial, personal use only. No information or materials published by Company constitutes a solicitation, an offer, or a recommendation to buy or sell any investment instruments, to effect any transactions, or to conclude any legal act of any kind whatsoever."
+      }
+    },
+    "leaderboards": {
+      "siteMetadata": {
+        "title": "Founding Members Leaderboards"
+      },
+      "title": "Leaderboard"
+    },
+    "form": {
+      "siteMetadata": {
+        "title": "Founding Members Form"
+      },
+      "title": "Submit activity summary",
+      "progressItem": {
+        "accountInfo": "Account info",
+        "keyFile": "Key file",
+        "summary": "Summary",
+        "acceptTerms": "Accept terms & conditions",
+        "acceptTermsShort": "Terms & cond."
+      },
+      "membership": {
+        "membershipHandle": "Membership handle",
+        "avatarAlt": "founding member avatar"
+      },
+      "json": {
+        "exportedAccount": "Exported account with key",
+        "howToExport": {
+          "link": "How to export your key?",
+          "title": "How to export your account with key:",
+          "text": "In the <0>Pioneer application</0> click the <1>My Keys</1> tab and then click the ellipsis (three dots) button on the Key which you would like to use. Then click <1>Create a backup file for this account</1>. Enter your password (if applicable) and the JSON will be downloaded."
+        },
+        "fileFormat": "Accepted file format: .json"
+      },
+      "keybaseAndText": {
+        "keybaseHandle": "Keybase handle",
+        "documentWithSummary": "Document with the summary",
+        "howToPrepare": {
+          "link": "How should I prepare it?",
+          "alternateLink": "How should I do it?",
+          "title": "How to prepare it:",
+          "text": "Your activity summary should describe in as much detail as possible your recent contributions to the success of the platform. Try to separate out each contribution into a separate paragraph or bullet point for ease of processing."
+        },
+        "fileFormat": "Accepted file format: .txt",
+        "password": "Password",
+        "pleaseEnterPassword": "Please enter your password!"
+      },
+      "termsAndConditions": {
+        "title": "Read and accept terms and conditions",
+        "text": "<0>Term</0><1>The Joystream Founding Member Program was formally launched during February 2021. The program will stop accepting new submissions (activity summaries) and awarding further leaderboard points approximately one month in advance of the mainnet launch, on the snapshot date, yet to be confirmed.</1><2><0>Our current target for mainnet launch is during Q4 2021, though this is subject to change.</0></2><0>Eligibility</0><1>The program is open to everyone over the age of 18 who are not U.S. persons. </1><1>To be formally admitted to the program you will be contacted and screened by a Jsgenesis representative once your community contributions have met our internally determined threshold for admission.</1><2>The formal admission of new Founding Members to the program will take place at the end of scoring periods (the dates of which are published on our website). Each scoring period currently lasts two weeks.</2><0>Communication</0><1>We will publish further public updates about the program through our regular communication channels, including our Official Discord Channel, the Joystream Newsletter, the official GitHub repo for the program (github.com/joystream/founding-members) and on our website (www.joystream.org), and blog (blog.joystream.org).</1><2>Any private or sensitive information about your participation in the program will be communicated via Keybase or some other previously agreed contact method.</2><0>Token Allocation Formula</0><1>Once officially awarded with Founding Member status, you will be automatically assigned 0.02% of the mainnet genesis token supply. The rest of your token allocation will be calculated based on your proportional share of leaderboard points among all Founding Members.</1><2>Since the current program provides a token pool of 15%, this 15% will be made up of claims of the default 0.02% by each participant, and the remaining allocation not already claimed under this rule will be distributed proportionally based on the relative share of total leaderboard points for each Founding Member.</2><0>Reward Policy</0><1>Points have no intrinsic value and when assigned to users with the Founding Member status they only represent a partial claim on an as yet undetermined quantity of mainnet JOY tokens. In the case of bad faith activity (see below), leaderboard/founding member points can be voided at any time.</1><2>Participants should also be aware that tokens allocated for mainnet may include some vesting period or \"locks\", that restricts what they can be used for some period of time.</2><0>Eviction Policy</0><2>Any platform member who participates in fraudulent or bad faith activity is liable to be expelled from the leaderboards and Founding Member program, with all associated token claims voided.</2><0>Account and Key Security</0><1>Your leaderboard/founding member points are yours alone and are non-transferrable. You must keep your account and any private keys associated with your membership of the Founding Member program safe and engage in sensible digital security practices.</1><1>Keys with associated Founding Member token claims must not be transferred to anyone else under any circumstances. Where this occurs, points or token claims may be voided (see above).</1><2>Tokens can only be allocated to addresses under your control. You may be required to sign a message proving you own the private keys to any addresses you provide.</2><0>Activity Reporting</0><1>You cannot claim for the same activity on more than one occasion (i.e. across more than one summary) in order to be awarded the same points twice. If this does occur it is liable to be deemed bad faith and may result in your eviction from the program.</1><1>All activity must be reported within 30 days of taking place. Contributions recorded outside of this window will not qualify for rewards. For this reason it is very important to submit regular summaries.</1><1>Once you have submitted your activity up to and including a certain date, you can no longer submit activity from before this date.</1><2>When reporting contributions, the correct format for summary submissions should be observed.</2><0>Updates To These Rules</0><1>Jsgenesis reserves the right to update the rules of the program at any time, for any reason.</1><1>If serious flaws in the structure of the program are discovered, Jsgenesis reserves the right to announce that after a future scoring period, the \"season\" is concluded, and a new scheme will apply to following seasons, thus resetting \"scores\". In such an event, a \"slice\" of the pool, set by Jsgenesis discretion, will be allocated in accordance with existing rules. The remainder will be transferred to new \"seasons\".</1><1>Jsgenesis reserves the right not to honour any aspect of this agreement due to legal considerations.</1>"
+      },
+      "success": {
+        "title": "Thank you for submitting your summary, we have received it successfully.",
+        "text": "We will process the information contained within it shortly and award leaderboard points for qualifying contributions."
+      },
+      "error": {
+        "noSuchAccount": "No such account exists. Try again!",
+        "incorrectPassword": "Password is incorrect, please try again!",
+        "fileFormat": "Wrong file format! Please try again or check our tips how to export it.",
+        "jsonWrongAccount": "Json file doesn't correspond to account given!",
+        "faultyJson": "Json file has incomplete/incorrect components. Try exporting your account again!"
+      },
+      "dropFile": "Drop you file here or <0>browse files</0>",
+      "uploadFile": "Upload file"
+    }
+  }
+}

--- a/src/locales/fr/general.json
+++ b/src/locales/fr/general.json
@@ -1,0 +1,135 @@
+{
+  "joystream": "Joystream",
+  "button": {
+    "getStarted": {
+      "text": "Start earning",
+      "altText": "Join & start earning"
+    },
+    "download": "Download",
+    "close": "Close",
+    "accept": "Accept",
+    "openDiscord": "Open Discord",
+    "learnMore": "Learn More",
+    "gettingStarted": "Getting Started"
+  },
+  "rolesData": {
+    "validator": "Validator",
+    "council": "Council",
+    "councilMember": "Council Member",
+    "storageProvider": "Storage Provider",
+    "contentCreator": "Content Creator",
+    "contentCurator": "Content Curator",
+    "discoveryProvider": "Discovery Provider",
+    "bandwidthProvider": "Bandwidth Provider",
+    "builder": "Builder",
+    "storageLead" : "Storage Lead",
+    "contentLead" : "Content Lead"
+  },
+  "siteMetadata": {
+    "title": "Joystream: The video platform DAO"
+  },
+  "colors": {
+    "joystreamBlue": "Joystream Blue",
+    "white": "White",
+    "joystreamGrey": "Joystream Grey",
+    "black": "Black"
+  },
+  "CMYK": "CMYK",
+  "RGB": "RGB",
+  "HEX": "HEX",
+  "orderedNumbers": {
+    "one": "01.",
+    "two": "02."
+  },
+  "numbers": {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7"
+  },
+  "roleCard": {
+    "migration": "At migration, {{numberOfUsers}} (max) had this role",
+    "current": "{{numberOfUsers}} run this role on Antioch",
+    "most": "At most, {{numberOfUsers}} users occupied this role",
+    "new": "NEW"
+  },
+  "heroCard": {
+    "active": "Network announced",
+    "error": "Network down",
+    "info": "Network replaced",
+    "finished": "Network live"
+  },
+  "dateCounter": {
+    "week": "week",
+    "weeks": "weeks",
+    "day": "day",
+    "days": "days",
+    "hour": "hour",
+    "hours": "hours",
+    "minute": "minute",
+    "minutes": "minutes",
+    "second": "second",
+    "seconds": "seconds",
+    "month": "month",
+    "months": "months",
+    "year": "year",
+    "years": "years",
+    "timeToLaunch": "Time to launch",
+    "launchedOn": "Launched on"
+  },
+  "sidebar": {
+    "activeRoles": "Active roles",
+    "upcomingRoles": "Upcoming roles",
+    "viewAllRoles": "View all Roles"
+  },
+  "navbar": {
+    "product": "Product",
+    "atlas": "Atlas",
+    "pioneer": "Pioneer",
+    "community": "Community",
+    "brandStory": "Brand Story",
+    "brandGuides": "Brand Guides",
+    "downloadAssets": "Download Assets",
+    "about": "About"
+  },
+  "footer": {
+    "title": "Stay up to date",
+    "alternateTitle": "Get notified",
+    "subtitle": "Don't worry about spam! Keep track of all important updates",
+    "inputPlaceholder": "Email Address...",
+    "joinNewsletter": "Join the newsletter",
+    "github": {
+      "whitepaper": "Whitepaper",
+      "repository": "Repository"
+    },
+    "usefulLinks": {
+      "title": "Useful links",
+      "hiring": "We are hiring!",
+      "brandGuidance": "Brand guidance"
+    },
+    "followUs": "Follow us"
+  },
+  "pages": {
+    "blog": "Blog",
+    "manifesto": "Manifesto",
+    "roles": "Roles",
+    "token": "Token",
+    "hydra": "Hydra",
+    "foundingMembers": "Founding Members",
+    "leaderboards": "Leaderboards",
+    "scoringForm": "Scoring form",
+    "overview": "Overview"
+  },
+  "socials": {
+    "twitter": "Twitter",
+    "github": "GitHub",
+    "discord": "Discord"
+  },
+  "cookiesNotice": {
+    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "findOutMore": "Find out more ›"
+  }
+}

--- a/src/locales/fr/get-started.json
+++ b/src/locales/fr/get-started.json
@@ -1,0 +1,56 @@
+{
+  "getStarted": {
+    "siteMetadata": {
+      "title": "Getting Started",
+      "description": "Learn how to contribute and participate to the Joystream project"
+    },
+    "hero": {
+      "title": "How to Contribute and Participate",
+      "subtitle": "Read more about the current ways you can add value to the project and earn rewards for doing so.",
+      "buttonText": "View opportunities",
+      "imageAlt": "getting started hero"
+    },
+    "howToStart": {
+      "title": "How to start",
+      "discord": "Join our Discord",
+      "tokens": "Receive free testnet tokens",
+      "membership": "Create membership on-chain",
+      "opportunities": "Pick one of the opportunities below"
+    },
+    "opportunities": {
+      "title": "Opportunities",
+      "bounties": {
+        "title": "Bounties",
+        "text": "Bounties are long running tasks which anyone can attempt to tackle in a exchange for some reward. They are created either by Jsgenesis, or by the Council.",
+        "imageAlt": "money pouch"
+      },
+      "bountiesCarousel": {
+        "all": "All",
+        "coding": "Coding",
+        "design": "Design",
+        "marketing": "Marketing",
+        "research": "Research",
+        "contentCreation": "Content Creation"
+      },
+      "roles": {
+        "title": "Roles",
+        "text": "Our current testnet also allows you to participate in some of the platform roles which will be available on mainnet.<0/><0/>Participation in these roles is rewarded in tJOY (our testnet token) which is backed by fiat reserves at Jsgenesis and redeemable for bitcoin cash.",
+        "imageAlt": "masks"
+      }
+    },
+    "activeRoles": {
+      "title": "Active roles on the current testnet",
+      "validatorText": "A Validator is an actor which checks the validity of newly constructed blocks, proposes new blocks and participates in the consensus process for committing new block to the chain. Validators are typically paid a fixed amount for each block produced. This role has a purpose very similar to that of the miners in the Bitcoin blockchain.",
+      "councilMemberText": "Council Members are elected by stakeholders in the system to act in the long-term interest of the platform. They are responsible for allocating resources, and hiring working group leads to run the platform's day-to-day operations. This is done through the proposal system, allowing any user to submit suggestions for changing the platform in some way.",
+      "storageProviderText": "There are critical platform assets that do not live on the blockchain, such as content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enable uploading and downloading of such data. The Storage Provider is involved this activity, specifically by storing large quantities of data.",
+      "storageLeadText": "The Storage Lead is hired directly by the Council through the proposals system and is dedicated to the hiring, firing and wider management of Storage Providers on the network.",
+      "contentCuratorText": "Content Curators are responsible for monitoring the publishing of new content into the content directory, and responding to reports about contested publications. They must also update information on content to ensure it is accurate, with correct metadata. Collaborating with Builders to improve tools and user-facing experiences is another significant part of the role.",
+      "contentCreatorText": "Content Creators are those platform participants who have decided to contribute their own original (or third-party licensed) content to the platform. There are no direct incentives for this informal role at this time, though effective contributors are very likely to be rewarded through the Founding Member Program.",
+      "contentLeadText": "The Council has the power to appoint a Content Curator Lead for the network who can hire further Content Curators. The Content Lead also decides on priorities for curation. If necessary, upon discussing with the council, the Lead can also decide to fire curators who are not performing their jobs adequately."
+    },
+    "roleCard": {
+      "overview": "Overview",
+      "buttonText": "Check details on GitHub"
+    }
+  }
+}

--- a/src/locales/fr/hydra.json
+++ b/src/locales/fr/hydra.json
@@ -1,0 +1,98 @@
+{
+  "hydra": {
+    "siteMetadata": {
+      "title": "Hydra - A Substrate query node framework",
+      "description": "Inspired by The Graph, it gives a smooth way to provide powerful GraphQL queries to app developers over your Substrate blockchain state and history."
+    },
+    "hero": {
+      "title": "Hydra - A Substrate query node framework",
+      "text": "Inspired by The Graph, it gives a smooth way to provide powerful GraphQL queries to app developers over your Substrate blockchain state and history."
+    },
+    "value": {
+      "title": "We make it simple",
+      "subtitle": "Building great apps talking directly to a Substrate full node is impossible, and simply trying is slow and hard.",
+      "values": {
+        "slowFetching": {
+          "title": "Slow Fetching",
+          "text": "Doing multiple read operations across multiple block heights is often required, and the pure latency of fetching the data is very bad. Some reads may depend on the result of prior ones, which results in sequential reads, which is even slower."
+        },
+        "slowProcessing": {
+          "title": "Slow Processing",
+          "text": "The client has to do all the work of filtering, sorting, paginating or otherwise computing on the resulting data, and this takes time, resulting in a slow client experience and CPU load on the user device."
+        },
+        "complexClient": {
+          "title": "Complex Client",
+          "text": "The fetching and processing logic is reproduced in all apps, and adds to the complexity of application development."
+        },
+        "noSearch": {
+          "title": "No Search",
+          "text": "Your chain may have transactional or state commitments to free-text data, but doing real full-text search client-side is not an option."
+        },
+        "overFetching": {
+          "title": "Over-Fetching",
+          "text": "You cannot select the data you want, you have to read full state objects as they are, wasting both connection and full node capacity."
+        },
+        "costlyNodes": {
+          "title": "Costly Archival Nodes",
+          "text": "User requests which involve multiple read operations. To fetch a consistent dataset, you will often have to read at some specific block height, as always reading at the tip can break atomicity. This means such read requests will depend on the full node being archival. As your user base scales, that will become a very costly infrastructure."
+        }
+      }
+    },
+    "snippet": {
+      "title": "Powerful queries in GraphQL",
+      "subtitle": "Provide application developers a powerful GraphQL API for your blockchain state and history"
+    },
+    "features": {
+      "title": "Hydra Features",
+      "values": {
+        "fullTextSearch": {
+          "title": "Full-text Search",
+          "text": "Decorate any number of String fields in the input schema with @fulltext(query: \"myquery\") to seach across different fields and entities."
+        },
+        "filtering": {
+          "title": "Filtering",
+          "text": "Any entity field can be used for OpenCRUD filtering"
+        },
+        "pagination": {
+          "title": "Pagination",
+          "text": "Each GraphQL query supports pagination out-of-the-box"
+        },
+        "ordering": {
+          "title": "Ordering",
+          "text": "Order by any primitive field"
+        },
+        "polymorphism": {
+          "title": "Polymorphism",
+          "text": "Native support of GraphQL interfaces and type inline fragments"
+        },
+        "algebraicTypes": {
+          "title": "Algebraic Types",
+          "text": "Construct rich and queriable algebraic types with @variant directive"
+        }
+      }
+    },
+    "videoTitle": "Play a video tutorial",
+    "getStarted": {
+      "title": "Get started with Hydra now!",
+      "subtitle": "Use the following links to connect with us and find out even more.",
+      "links": {
+        "documentation": {
+          "name": "Documentation",
+          "link": "Documentation"
+        },
+        "githubRepository": {
+          "name": "Github Repository",
+          "link": "Github repo"
+        },
+        "kusamaPlayground": {
+          "name": "Kusama Playground",
+          "link": "Go to the Playground"
+        },
+        "discord": {
+          "name": "Discord",
+          "link": "Go to the Channel"
+        }
+      }
+    }
+  }
+}

--- a/src/locales/fr/landing.json
+++ b/src/locales/fr/landing.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "siteMetadata": {
+      "description": "Joystream is a video platform controlled, owned, and operated by its users."
+    },
+    "hero": {
+      "title": "The video platform DAO",
+      "subtitle": "Joystream is a video platform controlled,<0/> owned, and operated by its users",
+      "metrics": {
+        "mainTitle": "Testnet Metrics",
+        "titles": {
+          "participationPayout": "Participation Payout",
+          "activeValidators": "Active Validators",
+          "blockHeight": "Block Height",
+          "memberships": "Memberships"
+        }
+      }
+    },
+    "becomeFM": {
+      "subtitle": "Our brand new and unparalleled community token distribution scheme",
+      "title": "Become a Founding Member to earn mainnet tokens and influence the development of the platform.",
+      "alternateTitle": "Become a Founding member and have a tangible impact on the development of our platform.",
+      "link": "Learn more about our generous program"
+    },
+    "whatWeDo": {
+      "subtitle": "Our motivation for building the Joystream protocol",
+      "title": "We call for an arrangement where media platforms are accountable to the people they impact.",
+      "link": "Read our manifesto"
+    },
+    "whyYouShouldJoin": {
+      "title": "Why join our testnets?",
+      "reasons": {
+        "tokens": {
+          "title": "Tokens",
+          "text": "Earn tokens distributed on mainnet, launching 2021"
+        },
+        "cash": {
+          "title": "Cash",
+          "text": "Get rewarded with real money for your participation"
+        },
+        "reputationAndSkill": {
+          "title": "Reputation & Skill",
+          "text": "Gain the knowledge required to participate on mainnet"
+        }
+      }
+    },
+    "exploreJoystream": {
+      "title": "Explore Joystream Now",
+      "subtitle": "Two fast evolving apps for consuming content and governance activities.",
+      "atlas": {
+        "text": "Atlas is the flagship content consumer and publishing app for Joystream. Watch videos, follow creators and discover new featured content, or create a channel and build your audience.",
+        "link": "Try out Atlas",
+        "imageAlt": "overview visual of Atlas"
+      },
+      "pioneer": {
+        "text": "Pioneer is the place to participate in community governance and operation. Vote on elections, submit proposals to fund your project or get enter a paid role to power the platform.",
+        "link": "Try out Pioneer",
+        "imageAlt": "overview visual of Pioneer"
+      }
+    },
+    "roadToMainnet": {
+      "title": "Road to mainnet",
+      "testnetState": {
+        "Current": "Current testnet",
+        "Past": "Past testnet",
+        "Future": "Future testnet"
+      },
+      "released": {
+        "Current": "Released on ",
+        "Past": "Released on ",
+        "Future": "Will be live on "
+      },
+      "testnets": {
+        "Sparta": {
+          "title": "Sparta testnet",
+          "text": "Sparta is our second testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Sparta"
+        },
+        "Athens": {
+          "title": "Athens testnet",
+          "text": "Athens is our third testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Athens"
+        },
+        "Acropolis": {
+          "title": "Acropolis testnet",
+          "text": "Acropolis is our fourth testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Acropolis"
+        },
+        "Rome": {
+          "title": "Rome testnet",
+          "text": "Rome is our second fifth, introducing a variety of important technical improvements.",
+          "explore": "Explore Rome"
+        },
+        "Constantinople": {
+          "title": "Constantinople testnet",
+          "text": "Constantinople is our sixth testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Constantinople"
+        },
+        "Alexandria": {
+          "title": "Alexandria testnet",
+          "text": "Alexandria is our second seventh, introducing a variety of important technical improvements.",
+          "explore": "Explore Alexandria"
+        },
+        "Babylon": {
+          "title": "Babylon testnet",
+          "text": "Babylon is our second eighth, introducing a variety of important technical improvements.",
+          "explore": "Explore Babylon"
+        },
+        "Antioch": {
+          "title": "Antioch testnet",
+          "text": "Antioch is our ninth testnet, patching a chain split bug which broke the Babylon network",
+          "explore": "Explore Antioch"
+        },
+        "Sumer": {
+          "title": "Sumer testnet",
+          "text": "Sumer is our tenth testnet, facilitating easy content uploads via our playback app.",
+          "explore": "Explore Sumer"
+        }
+      }
+    },
+    "earnTokens": {
+      "title": "Earn mainnet tokens, cash and influence."
+    }
+  }
+}

--- a/src/locales/fr/manifesto.json
+++ b/src/locales/fr/manifesto.json
@@ -1,0 +1,72 @@
+{
+  "manifesto": {
+    "siteMetadata": {
+      "description": "Read the Joystream Manifesto"
+    },
+    "hero": {
+      "title": "The Joystream Manifesto",
+      "text": "Our Manifesto sets out both the problems we believe are associated with digital media platforms in their current form as well as our proposed solution to these concerns."
+    },
+    "problem": {
+      "title": "Problem",
+      "text": {
+        "artAsTool": "We believe that art, be it as literature, music, film, games or performance, is a critical tool through which societies establish a shared understanding of what is common knowledge among all members. These expressions define values and narratives that end up shaping culture, faith and even public policy. It therefore matters deeply how it is financed, distributed and paid for.",
+        "mediaAsPrimaryMedium": "Digital media has become the primary medium through which such expression is distributed, and digital media platforms have become the key institutions organizing this activity.",
+        "unaccountableInstitutions": "Unfortunately, due to network effects, economies of scale, regulations and political interests, we are today left with handful of massive institutions which set the terms for how this happens. They are almost entirely unaccountable to normal market and political mechanisms.",
+        "filteredOnTheirTerms": "As a result, our stories, expressions and interactions are managed and filtered on their terms. This continues to generate an ever changing set of problems, be it",
+        "inflexible": "inflexible monetization, censorship of controversial speech, inequitable sharing of gains with creators and audience, low platform innovation or lack of credibility with third party developers."
+      }
+    },
+    "goal": {
+      "title": "Goal",
+      "text": {
+        "arrangement": "We call for an arrangement where media platforms are accountable to the people they impact, which are primarily their users, be it as consumers, creatives, third party developer or workers.",
+        "accountability": "It is the absence of such accountability which is the fundamental source of any particular problem at any particular time."
+      }
+    },
+    "thesis": {
+      "title": "Thesis",
+      "text": {
+        "coreThesis": "Our core thesis is that there are two basic challenges which must be addressed to achieve this goal, and that an appropriate application of contemporary distributed systems technology, including blockchains, smart contracts and tokens, is the right means to do so."
+      }
+    },
+    "wedge": {
+      "title": "The Wedge",
+      "text": {
+        "alternative": "First is the question of how to create an alternative from scratch in the face of platform externalities which make any new platform nearly useless, regardless of any of its inherent characteristics. The process of doing this sort of bootstrapping has historically been mostly an art, where success has rarely been reproducible.",
+        "blockchainTokens": "We believe that blockchain tokens, earned by and issued to early participants, have been shown to be extremely effective at mobilizing, integrating and motivating an international and dynamic community.",
+        "initialHurdle": "This has now repeatedly allowed nascent communities, like the Bitcoin community, to overcome the initial network effect hurdle [1, 2, 3]. There is no certainty that this will be sufficient, but we believe this mechanism is as promising as anything which is likely to have a chance in a long time."
+      }
+    },
+    "accountability": {
+      "title": "Accountability at scale",
+      "text": {
+        "createAndSustain": "Second is the question of how to create and sustain accountability in such a platform when it actually reaches scale.",
+        "twoWays": "We understand there to be two fundamental ways that participants can hold institutions of any kind accountable: Voice and exit, in the tradition of Hirschman A. O. [4]."
+      }
+    },
+    "voice": {
+      "title": "Voice",
+      "text": {
+        "improveWithin": "Voice is the approach of attempting to improve or reform the functioning of an institution from within. The effectiveness of this depends on some capacity to both share reliable information with other members, and have some impact on internal governance processes. Current media platforms provide users no effective way of doing either.",
+        "infrastructure": "We believe that blockchains provide an organizational and economic infrastructure which can address both problems. The public, verifiable and immutable history of economic and administrative records, provides an excellent basis for users to understand the current and past state of the platform. This allows anyone to make incontestable claims about relevant facts and circumstances.",
+        "control": "Further, blockchain tokens allow us to make use and control of a platform inseparable, giving users an automatic seat at the table in deliberating over platform level decisions.",
+        "signWithCrypto": "All that is required to establish, exercise or transfer the capacity to participate in such activity, is the ability to sign messages with identifiable cryptographic keys. Perfectly reliable contracting gives a large, dynamic and unrestricted set of users the means of governing the platform. This can serve a wide range of purposes, such as undertaking projects, regulating participation in different formally specified roles, or even updating the institutional rules themselves. This integration of reliable contracting into the economic rails provides an organizational infrastructure much more in line with our objectives of inclusive control than the normal jurisdictional trust based infrastructure."
+      }
+    },
+    "exit": {
+      "title": "Exit",
+      "text": {
+        "exit": "Exit is the approach of entirely ending participation in an institution in favor of either joining or creating an alternative. The effectiveness of this depends on costs of leaving, and either joining or creating an alternative, all being low compared to the deprivation in the existing institution. This is currently not the case.",
+        "loweredCosts": "By building platforms based on free & open source software, open protocols and open data — as is the case with Blockchain systems, one dramatically lowers these costs. Since users control their own data, identity and assets, they have a much easier time joining new platforms, and even taking their peers with them.",
+        "competition": "Open protocols and data will make multi homing interfaces abundant, where users may not even need to switch, but instead use multiple platforms simultaneously, which encourages platform level competition [5].",
+        "reusability": "Even more dramatically, reliance on open source means that all the software capital of a platform can easily be reused, and since the entire organizational state is also public, entire ecosystems can be forked to create new alternative platforms with modified policies and objectives."
+      }
+    },
+    "ctaText": "This plan still has room for more people, so get involved by sending an <0>email</0> or joining us on <1>Discord</1> or <2>Reddit</2>.",
+    "references": {
+      "title": "References",
+      "text": "<0>[1] Ersam, F. Blockchain Tokens and the dawn of the Decentralized Business Model. Medium. Aug 1, 2016.</0><0>[2] Srinivasan, B. S. Thoughts on Tokens. Medium. May 27, 2017.</0><0>[3] Dixon, C. Crypto Tokens: A Breakthrough in Open Network Design. Medium. June 1, 2017.</0><0>[4] Hirschman, Albert O. Exit, voice, and loyalty: Responses to decline in firms, organizations, and states. Vol. 25. Harvard university press, 1970.</0><0>[5] Rochet, Jean‐Charles, and Jean Tirole. “Platform competition in two‐sided markets.” Journal of the european economic association 1.4 (2003): 990–1029.</0>"
+    }
+  }
+}

--- a/src/locales/fr/privacy-policy.json
+++ b/src/locales/fr/privacy-policy.json
@@ -1,0 +1,59 @@
+{
+  "privacyPolicy": {
+    "siteMetadata": {
+      "description": "Joystream Privacy and Cookie Policy"
+    },
+    "hero": {
+      "title": "Privacy Policy and Cookies",
+      "text": "<0><0>Jsgenesis values your privacy.</0><1/><1/>This Privacy Policy (\"Privacy Policy\") and Cookie Policy (\"Cookie Policy\") explains how Jsgenesis AS (\"Jsgenesis\", \"Company\", \"We\", \"Us\", \"Our\") collect and use data and information when you (\"User) use on or any of the Joystream products, developed in the GitHub organization <3>Joystream</3>. These products (collectively \"Software\") include, but are not limited to, all pages under the <6>joystream.org</6> domain (\"Website\"), the <10>Joyful node</10> (\"Full Node\"), the <14>Colossus Storage Node</14> (\"Storage node\"), and the Pioneer User Interface, either <18>self hosted</18> or <22>hosted by Us</22>  (\"App\").</0>"
+    },
+    "terms": {
+      "title": "Relevant to the Privacy Policy and Cookie Policy are the following terms:",
+      "blockchain": "The term <0>\"Blockchain\"</0> refers to the blockchain(s) assembled by the Full Node.",
+      "content": "The term <0>\"Content\"</0> refers to media files accessible through our Software.",
+      "keys": "The term <0>\"Keys\"</0> refers to a private/public cryptographic keypair, that Users can generate in order to write (and decrypt data) on the Blockchain.",
+      "membership": "The term <0>\"Membership\"</0> refers to tying your Keys to a public profile, allowing users to access Content and interact with the Blockchain.",
+      "memo": "The term <0>\"Memo\"</0> refers to a markdown enabled text field, where users can input data tied to their Keys."
+    },
+    "privacyPolicyItems": {
+      "title": "Privacy Policy",
+      "subtitle": "Last updated on the 17th of April 2019",
+      "agreement": {
+        "title": "1. Agreement to the Policy",
+        "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
+      },
+      "changes": {
+        "title": "2. Changes to Policy",
+        "content": "This Privacy Policy may be changed at the sole discretion of Company. If any material changes are made, the User will be notified in the Service that is used. Note that adding new products to be included in the term Software, e.g. a new User facing product replacing the App or a new tool for uploading Content, is not considered material as it will not affect Users unless they adopt the new product. Changing software names, terminology used in this Privacy Policy, and changing link locations are also examples of non-material changes."
+      },
+      "informationCollected": {
+        "title": "3. Information Collected",
+        "content": "All data written to the Blockchain, is implicitly collected not only by Company, but also anyone else in the world that is running the Full Node locally, or accessed via the App or a third party. This includes, but is not limited to, Content hashes, Membership profile, Memo field, and any other way a User can record data on the Blockchain. ‍<0/><0/> When using the <1>faucet</1> subpage of the Website, Company will record the IP address behind every new request for tokens. This data will be deleted every 14 days."
+      },
+      "googleAnalytics": {
+        "title": "",
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+      }
+    },
+    "cookiePolicyItems": {
+      "title": "Cookies Policy",
+      "subtitle": "Last updated on the 17th of April 2019",
+      "whatAreCookies": {
+        "title": "1. What are Cookies?",
+        "content": "Cookies are small pieces of text sent by your web browser by a website you visit. A cookie file is stored in your web browser and allows the Service or a third-party to recognise you and make your next visit easier and the Service more useful to you. ‍<0 />‍<0 /> Cookies can be persistent or session cookies."
+      },
+      "howWeUseCookies": {
+        "title": "2. How we use Cookies",
+        "content": "We use cookies for the following purposes our Service: <0 /><0 /><1><0>Provide Analytics</0><0>Store preferences</0><0>Persistant local storage of Keys and Membership.</0></1>"
+      },
+      "thirdPartyCookies": {
+        "title": "3. Third-party Cookies",
+        "content": "In addition to our own cookies, we also use various third-party cookies to report usage statistics of the Service, deliver advertisements on and through the Service, and so on. They include:<0/><0/><1><0><0>Google Analytics</0></0><0><0>Mailchimp</0> (Only when signing up for any of our newsletters)</0><0><0>Godaddy</0></0></1><0 />Please see Item 3. of the Privacy Policy for more information on the extent of these providers."
+      },
+      "regardingYourCookies": {
+        "title": "Regarding Your Cookies",
+        "content": "If you would like to delete cookies or instruct your web browser to delete or refuse cookies, please visit the help pages of your web browser.<0 />‍<0 /> Please note, however, that if you delete cookies or refuse to accept them, you might not be able to use all of the features we offer, you may not be able to store your preferences, and some of our pages might not display properly."
+      }
+    }
+  }
+}

--- a/src/locales/fr/roles.json
+++ b/src/locales/fr/roles.json
@@ -1,0 +1,197 @@
+{
+  "roles": {
+    "siteMetadata": {
+      "description": "Read more about current and future roles on the Joystream platform"
+    },
+    "hero": {
+      "title": "Choose your preferred role",
+      "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."
+    },
+    "validator": {
+      "title": "Validator",
+      "overview": "The Joystream platform state lives on a blockchain consensus system. This consensus system is a variant of classical BFT consensus combined with Proof-of-Stake to determine voting power. A validator is an actor which checks the validity of newly constructed blocks, proposes new blocks and participates in the consensus process for committing new block to the chain. This role has a purpose very similar to the miners in the Bitcoin blockchain. Importantly, anyone can fully check the validity of the blockchain, not just validators, and this is called validation.",
+      "responsibilities": {
+        "runAndMaintainScreeningNodes": "Run and maintain screening nodes that are always available and performant",
+        "enforceRules": "Help enforce the consensus rules of the network"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage, (up & down) bandwidth and processing capacity",
+        "storeKeys": "Able to securely store keys",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "councilMember": {
+      "title": "Council Member",
+      "overview": "At the heart of the governance process on the platform is the proposal system, which allows anyone to submit some suggestion for changing the state or policy of the platform in some way. These proposals are processed and voted on by a council, where the participants are referred to as council members. A seat on the council is won through an election process, and lasts for some period of time until a new election.",
+      "responsibilities": {
+        "discussProposals": "Discuss the meaning and merits of incoming proposals, covering a broad range of topics",
+        "vote": "Vote on proposals",
+        "representCommunity": "Represent the community members and your constituency to make day-to-day operations decisions"
+      },
+      "requirements": {
+        "dataAnalysisProficiency": "Proficiency with basic data analysis and sufficient reputation and standing within the community to earn supporting votes in elections from other platform members",
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure, function and resource allocation",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "storageProvider": {
+      "title": "Storage Provider",
+      "overview": "There are critical platform assets that do not live on the blockchain, such as images and content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enables uploading and downloading of such data. The storage provider is involved this activity, specifically by storing large quantities of data.",
+      "responsibilities": {
+        "runAndMaintainStorageNodes": "Run and maintain storage nodes that store very large quantities of static data, synchronize with other storage nodes, share data with distributors, and accepts inbound uploads from end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure with high storage capacity",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "storageLead": {
+      "title": "Storage Lead",
+      "overview": "The Storage Lead is hired directly by the Council through the proposals system and is dedicated to the hiring, firing and wider management of Storage Providers on the network.",
+      "responsibilities": {
+        "storageProviderPerformance": "The Storage Lead is responsible for ensuring that Storage Providers are performing adequately. Each one must hold a complete and up-to-date copy of the content directory and ensure uptime in order to effectively serve content consumers."
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "managementAndCoordination": "Ability to effectively manage and coordinate the actions of the Storage Providers",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentCurator": {
+      "title": "Content Curator",
+      "overview": "All of the media content published on the platform lives in an on-chain content directory. There are a range of different content types, and each type has a schema for a rich description of its structure, function and policies. For the effective use of of content, for example in rendering, discovery and monetization, it is critical to ensure the validity of the published information for all content. In particular, it is also important to resolve possible disputes about ownership and presence of any piece of content on the platform. It is the task of the content curators to do the work involved in processes that address these objectives.",
+      "responsibilities": {
+        "monitorContent": "Monitor the publishing of new content into the content directory, and respond to reports about contested publications",
+        "adjudicateDisputes": "Adjudicate possible dispute processes resulting from reports from users",
+        "updateContentInformation": "Update information on content to be accurate",
+        "collaborateWithBuilders": "Collaborate with <0> Builders</0> to improve both tools, and user facing experiences, to improve the integrity of the content directory"
+      },
+      "requirements": {
+        "adjudicateDisputes": "Fairly adjudicate disputes, and communicate in clear and transparent way with stakeholders and participants",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentCreator": {
+      "title": "Content Creator",
+      "overview": "As a video platform, one of the most important platform assets is the content published on the platform. Since video is such a flexible media type, which can encompass a wide range of content categories, it is the primary focus. However, the intention is to support a broader range of content types over time. The content creators are those involved in creating, publishing and monetizing content on the platform.",
+      "responsibilities": {
+        "publishContent": "Publish content and build an audience"
+      },
+      "requirements": {
+        "publishContent": "Have the right to publish existing or new content to the platform",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentLead": {
+      "title": "Content Lead",
+      "overview": "The Council has the power to appoint a Content Curator Lead for the network who can hire further Content Curators. The Content Lead also decides on priorities for curation. If necessary, upon discussing with the council, the Lead can also decide to fire curators who are not performing their jobs adequately.",
+      "responsibilities": {
+        "monitorPublishing": "Monitor the publishing of new content into the content directory, and respond to reports about contested publications",
+        "adjudicateDisputes": "Adjudicate possible dispute processes resulting from reports from users",
+        "updateInformation": "Update information on content to be accurate",
+        "manageAndCoordinate": "Manage and coordinate the actions of the Content Working Group"
+      },
+      "requirements": {
+        "adjudicateDisputes": "Fairly adjudicate disputes, and communicate in clear and transparent way with stakeholders and participants",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "membershipScreener": {
+      "title": "Membership Screener",
+      "overview": "A membership is an integrated representation of identifying information and associated activities of an actor on the platform. The direct way of establishing membership will be to simply pay a one time fee. However, since its currently challenging for many prospective non-technical end users to obtain, store and use crypto assets, there will be a way for users to get a membership for free, which will not require any tokens in order to use the platform in a limited capacity. The membership screener is the role responsible for granting such memberships, while screening for Sybill attackers and abusers.",
+      "responsibilities": {
+        "runAndMaintainScreeningNodes": "Run and maintain screening nodes that are always available and performant",
+        "collaborate": "Collaborate with <0>Membership Curators</0> and <1>Builders</1> to improve screening mechanisms by discussing screening techniques, sharing traffic information",
+        "beResponsive": "Be responsive and reactive to changing circumstances"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage, (up & down) bandwidth and processing capacity",
+        "onlinePlatformAttackFamiliarity": "Familiarity with how online platforms are attacked through botnets, IP anonymization, automated agents, etc.",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "membershipCurator": {
+      "title": "Membership Curator",
+      "overview": "A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described <0> above</0>. Since this is invariably an imperfect process, there must be some means by which bad conduct and fake accounts can be disabled or removed. This is the task of the membership curators.",
+      "responsibilities": {
+        "monitorPlatformActivity": "Monitor platform level activity for abuse and collusion",
+        "proposeChanges": "Propose changes to status of memberships which are identified, and participate in any dispute process which may follow",
+        "collaborate": "Collaborate with <0> Screeners</0> and <1> Builders</1> to improve tools for identifying such members"
+      },
+      "requirements": {
+        "dataAnalysisProficiency": "Proficient with basic data analysis and scripting",
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure, function and attack vectors",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "bandwidthProvider": {
+      "title": "Bandwidth Provider",
+      "overview": "There are critical platform assets that do not live on the blockchain, such as images and content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enable uploading and downloading of such data. The bandwidth provider is involved this activity, specifically by distributing static data to end users at scale.",
+      "responsibilities": {
+        "runAndMaintainDistributorNodes": "Run and maintain distributor nodes that deliver large volumes of upstream data to a large number of simultaneous end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage capacity and a lot of upstream capacity",
+        "locatedWithinBounds": "Located within certain bounds to designated geographic areas, in order to limit latency",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "discoveryProvider": {
+      "title": "Discovery Provider",
+      "overview": "All of the content on the platform is in a designated content directory, and effectively navigating this directory requires a full copy of this directory. Moreover, in order to do things like search and context based recommendations one needs to apply some sort of heuristic on top of this directory, which is also some what sensitive abusive attempts to rank higher. The discovery providers play the role of responding to such discovery queries to end users, by combining light client inclusion proofs with local search and ranking policy heuristics.",
+      "responsibilities": {
+        "runAndMaintainDiscoveryNodes": "Run and maintain discovery nodes that respond to discovery-related queries by staying in sync with the content directory, and applying local ranking heuristics.",
+        "collaborate": "Collaborate with <0>Builders</0> to improve both tools, and user facing experiences, to improve the discovery experience"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure",
+        "formulateAndTestHeuristics": "Able to formulate, test and suggest new ranking heuristics for use by discovery provider nodes",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "liveStreamingProvider": {
+      "title": "Live Streaming Provider",
+      "overview": "The platform supports live video, allowing publisher to distribute content as it is created. The live streaming providers are responsible for directly, or indirectly from peer providers, taking a (transcoded) stream from the source publisher, and relaying it to end users.",
+      "responsibilities": {
+        "runAndMaintainLivestreamingNodes": "Run and maintain live streaming nodes that deliver large volumes of upstream data to a large number of simultaneous end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with large amount of upstream bandwidth capacity.",
+        "locatedWithinBounds": "Located within certain bounds to designated geographic areas, in order to limit latency",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "builder": {
+      "title": "Builder",
+      "overview": "The platform runtime, tools, infrastructure software and user facing applications are all meant to evolve over time. A diverse set of contributors are required to facilitate this, including <0/><0/> <1> <0><0>Developers:</0> Software developers, Data scientists, DevOps and QA </0><0><0>Designers:</0> Web, Mobile, UX/UI, Branding and Visual Design </0> <0><0>Product Managers:</0> Digital Product Managers, Product Owners and Analysts </0> </0> <0 /> All of these contributors are collectively referred to as Builders. Anyone can contribute in the same mode as any of these possible contributor functions, as all the platform source assets are open source and developed in the open. Being a Builder means that one has some scope of responsibility in ongoing efforts, and that one has some predefined reward scheme associated with this responsibility.",
+      "responsibilities": {
+        "collaborate": "Collaborate with almost every other kind of platform member to maintain and improve the platform"
+      },
+      "requirements": {
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure and function",
+        "specificContributingSkills": "Have specific skills required for contributing in the given way",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "communicationModerator": {
+      "title": "Communication Moderator",
+      "overview": "The platform will have multiple ways of facilitating easy and secure public, and private, communication and information sharing among members. In particular, there will be both a forum and messaging capability built in to the platform. But in order for these spaces to be effective communication modes, some moderation will be required. Communication moderators are involved with policing this activity.",
+      "responsibilities": {
+        "monitorCommuncationChannels": "Monitor and supervise public communication channels for compliance with usage policies as decided through the governance system",
+        "communicateWithUsers": "Communicate with end users about any possible violations and sanctions",
+        "collaborate": "Collaborate to come up with new policies as circumstances change"
+      },
+      "requirements": {
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure and function",
+        "goodCommunicator": "Clear written communicator, ideally with good command of more than one language",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    }
+  }
+}

--- a/src/locales/fr/rome.json
+++ b/src/locales/fr/rome.json
@@ -1,0 +1,59 @@
+{
+  "rome": {
+    "siteMetadata": {
+      "description": "Explore the Rome testnet"
+    },
+    "hero": {
+      "title": "Rome Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY CONSTANTINOPLE ON"
+    },
+    "modal": {
+      "title": "Rome",
+      "text": "<0>The Roman empire left many landmarks.</0> Their architecture and engineering skills was unparalleled during their might. The concept of aqueducts was not devised by the Romans, but their beauty and extent is."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "No specifications were published for Rome."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "contentDirectory": {
+          "title": "Build a dynamic, flexible and user friendly content directory",
+          "text": "The Rome testnet is built around the introduction of a new content directory, that can be added to, modified and improved without requiring runtime upgrades. All key results and goals are derived from this."
+        },
+        "content": {
+          "title": "Populate the content directory with a variety of content",
+          "text": "Rome introduces a Content Directory system that is both built to last, yet still meant to be continuously improved on. We will pay for Content Creators to upload a variety of content and we hope to learn a lot from the results."
+        },
+        "contentCurator": {
+          "title": "Introduce the new Content Curator role",
+          "text": "With a new Content Directory, and incentives to upload content, we need monitoring. The Content Curators will require staking, and will be paid in both testnet tokens and Monero."
+        },
+        "contentCreator": {
+          "title": "Add Content Creator profiles",
+          "text": "Without Content Creators, there won't be any content. Granted, adding another level on top of the membership requirement may seem like a hurdle, but it will allow users to upload with multiple profiles."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Rome Network"
+    },
+    "map": {
+      "title": "Rome",
+      "text": "<0>Rome was the capital of the great Roman Empire during its peak.</0> As with previous testnet names, the Roman Empire and Rome was another important step in the rise of democracy, the rule of law, and modern governance structures.<1/><1/><2><0/> Explore current testnet</2>"
+    }
+  }
+}

--- a/src/locales/fr/sparta.json
+++ b/src/locales/fr/sparta.json
@@ -1,0 +1,41 @@
+{
+  "sparta": {
+    "siteMetadata": {
+      "description": "Explore the Sparta testnet"
+    },
+    "hero": {
+      "title": "Sparta Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "NETWORK DOWN",
+      "markdown": "\n ### FAILURE IDENTIFIED\n\n  On Friday the 29th of March, the Sparta network went down due to a [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) that we had not pulled down before release.\n\n  More details can be found in this [blog post](https://blog.joystream.org/sparta-sacked/)."
+    },
+    "modal": {
+      "title": "Helmet of Sparta",
+      "text": "<0>The Spartan army helmet</0> represents what Sparta is most known for today, their military might. For it's time, it was also known for its advanced governance system."
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our release OKR.",
+      "goals": {
+        "blockchain": {
+          "title": "Build and release a blockchain with a working Council",
+          "text": "As a \"user governed media platform\", allowing users to elect <0>Council Members</0> to represent their interest in day-to-day operations was a major goal for us."
+        },
+        "bugs": {
+          "title": "Keep the quantity of more or less critical bugs at an acceptable level",
+          "text": "As demonstrated by the fact that the network crashed, we did not reach our goals in this case."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Sparta testnet"
+    },
+    "map": {
+      "title": "The city of Sparta",
+      "text": "<0>Sparta was a prominent city-state in Ancient Greece.</0> In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution. <1/><1/> We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law, however draconian by modern standard."
+    }
+  }
+}

--- a/src/locales/fr/sumer.json
+++ b/src/locales/fr/sumer.json
@@ -1,0 +1,47 @@
+{
+  "sumer": {
+    "siteMetadata": {
+      "description": "Explore the Sumer testnet"
+    },
+    "hero": {
+      "title": "Sumer Network",
+      "text": "Among other changes, the Sumer testnet release offers major improvements to content uploads through our playback app."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Sumer testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Sumer testnet.",
+      "goals": {
+        "contentPublishing": {
+          "title": "Enable content publishing from playback interface",
+          "text": "Sumer introduces the ability to create and manage channels and videos in the Joystream Player, replacing the cumbersome and technically challenging CLI-dependent process required on the Antioch testnet."
+        },
+        "deployingNewContentDirectory": {
+          "title": "Deploying the new content directory",
+          "text": "As part of Sumer we will be introducing a simple native runtime module. This is because technical complexities and tradeoffs associated with the previous iterations of the content directory were not acceptable."
+        },
+        "enableBuilderRole": {
+          "title": "Enable builder/platform operations role",
+          "text": "We are introducing a new working group focused on platform operations. Originally, we had also planned to enable the new \"Gateway\" role, though this is no longer in the scope of the Sumer release."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Sumer Network"
+    },
+    "map": {
+      "title": "Sumer",
+      "text": "<0>Sumer is the earliest known civilization in the historical region of southern Mesopotamia</0>, emerging during the Chalcolithic and early Bronze Ages between the sixth and fifth millennium BC.<1/><1/>Living along the valleys of the Tigris and Euphrates, Sumerian farmers grew an abundance of grain and other crops, the surplus from which enabled them to form urban settlements. The region is thought to be where the earliest forms of writing emerged.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/fr/token.json
+++ b/src/locales/fr/token.json
@@ -1,0 +1,67 @@
+{
+  "token": {
+    "siteMetadata": {
+      "title": "Token",
+      "description": "Participants on our testnets can now earn Joystream Testnet Tokens (tJOYs) backed by fiat currency."
+    },
+    "hero": {
+      "title": "Understanding the tJOY token",
+      "text": "Participants on our testnets can now earn Joystream Testnet Tokens (tJOYs) backed by fiat currency.",
+      "tokenStats": {
+        "title": "Token in numbers",
+        "exchangeRate": "Exchange Rate",
+        "backingValue": "Backing Value",
+        "supply": "Supply"
+      }
+    },
+    "faq": {
+      "title": "Testnet Token Information",
+      "whatIsTJoy": {
+        "title": "What is tJOY?",
+        "text": "tJOY (testJOY) is the currency used on Joystream incentivized testnets."
+      },
+      "tJoyValueOrigin": {
+        "title": "Where does the value of tJOY come from?",
+        "text": "Jsgenesis, the team behind the Joystream project, have linked the total supply of tJOYs to a corresponding pool of fiat currency (USD) held by the company. All testnet participants can redeem their tJOY for USD at any time."
+      },
+      "purposeOfTJoy": {
+        "title": "What is the purpose of tJOY?",
+        "text": "tJOY can be used on our testnets in the same ways that future users of the Joystream platform will be able to use the mainnet JOY token. The three principal functions of tJOY are in staking, governance and for payment.<0/><0/> For example, to participate in testnet roles, users may need to stake tJOY. To create governance proposals and vote for Council Members, tJOY is also required. Finally, on the testnet, bounties and KPIs require tJOYs for paying effective contributors."
+      },
+      "whereCanTJoyBeObtained": {
+        "title": "Where can I get tJOY?",
+        "text": "There are many opportunities to obtain tJOY. Smaller amounts can be requested in our community channels (including our Discord server and on-chain forum), while larger sums can be accumulated by participating in bounties, competitions and other events."
+      },
+      "linkBetweenTJoyAndFutureToken": {
+        "title": "Is there any link between tJOY and the future mainnet token?",
+        "text": "There is no direct link between tJOY and mainnet JOY. We are using tJOY to simulate the real economic incentives present on mainnet to aid the platform's development and facilitate the growth and education of our community in preparation of the transition from testnet to mainnet."
+      },
+      "howToCashout": {
+        "title": "How do I cashout tJOY to USD?",
+        "text": "We use Bitcoin Cash (BCH) as a payment rail on our testnets. You can cashout tJOY by making a transfer to the dedicated burn address: <0>5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMaeKQu</0> Before doing this, you should set the <0>memo</0> of the key from which the transfer is made to your BCH address. At the moment of the transfer, the BCH to USD exchange rate is locked. <1/><1/>More information on payouts can be found <2>here</2>."
+      },
+      "howToEarn": {
+        "title": "How can I earn mainnet JOY?",
+        "text": "Currently, the only way to secure an allocation of mainnet JOY is through high-quality contributions to the platform and community via our <0>Founding Member Program</0>."
+      },
+      "TJoyWorth": {
+        "title": "How much is tJOY worth?",
+        "text": "You can check the live exchange rate (tJOY->USD) on this page (see above)."
+      }
+    },
+    "cashouts": {
+      "title": "Pending cashouts",
+      "subtitle": "Tokens sent to Jsgenesis in this exchange are burned, hence the final price of the token is unaffected by such an exchange.",
+      "cashout": {
+        "address": "Source address",
+        "tokensTransferred": "Tokens transferred",
+        "usdValue": "USD Value",
+        "blockNumber": "Block Number",
+        "exchangeNumber": "Exchange #"
+      }
+    },
+    "cta": {
+      "title": "Join our Discord and change the online video industry"
+    }
+  }
+}

--- a/src/locales/zh/about.json
+++ b/src/locales/zh/about.json
@@ -1,0 +1,51 @@
+{
+  "about": {
+    "general": {
+      "roles": {
+        "blockchain": "Blockchain Engineer",
+        "frontEnd": "Front-End Engineer",
+        "design": "Designer",
+        "growth": "Growth",
+        "core": "Core",
+        "ceo": "CEO",
+        "cto": "CTO",
+        "cooAndGrowth": "COO & Growth",
+        "all": "All",
+        "allMembers": "All members"
+      }
+    },
+    "siteMetadata": {
+      "title": "About us",
+      "description": "We don't just offer great compensation and flexibility, but the perfect mission, team and timing for you to build something that changes everything."
+    },
+    "hero": {
+      "title": "We are building Joystream to set it free",
+      "subtitle": "Jsgenesis is the core team building Joystream the platform and open-source blockchain."
+    },
+    "ourTeam": {
+      "title": "Our team",
+      "subtitle": "We come from different continents, but share a passion for open source, blockchain technology, distributed systems, privacy and building a new internet based on accountable and forkable institutions.",
+      "moreMembers": "Load more team members"
+    },
+    "investors": {
+      "title": "Our investors"
+    },
+    "positions": {
+      "title": "Open positions",
+      "available": "3 jobs available",
+      "join": "Join",
+      "roles": {
+        "frontEnd": "Front-end Developer",
+        "blockchain": "Blockchain Developer",
+        "designer": "UI/UX Design Lead"
+      },
+      "location": "Oslo, Europe, Remote",
+      "employmentType": "Full time",
+      "salary": {
+        "frontEnd": "$80K-$130K",
+        "blockchain": "$100K-$140K",
+        "designer": "$100K-$140K"
+      }
+    }
+  }
+}

--- a/src/locales/zh/acropolis.json
+++ b/src/locales/zh/acropolis.json
@@ -1,0 +1,59 @@
+{
+  "acropolis": {
+    "siteMetadata": {
+      "description": "Explore the Acropolis testnet"
+    },
+    "hero": {
+      "title": "Acropolis Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ROME ON"
+    },
+    "modal": {
+      "title": "The Acropolis of Athens",
+      "text": "<0>Known for its great architecture, Acropolis'</0> perhaps most famous building is the Parthenon. It was built to celebrate their victory over Persian invaders, and is today seen as a symbol for democracy and western civilization."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "Read the specs of the newly implemented features of Acropolis."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "forum": {
+          "title": "Build and release an on-chain forum",
+          "text": "The final platform will have built in multiple ways of facilitating easy and secure public, and private, communication and information sharing among members. The forum is the first step allowing the platform members to communicate, share ideas and discuss."
+        },
+        "storageNode": {
+          "title": "Rebuild and release the storage node",
+          "text": "Where the old storage node had some bugs making it unable to sync between clients and required a hardcoded liaison, the new storage node is working as intended with no hierarchy or privileges."
+        },
+        "storageProviders": {
+          "title": "Ensure high uptime of storage providers",
+          "text": "Both content creators and consumers user experience depends on various metrics, but perhaps the most important is that the storage node they connect to responds to their request. Whether or not this goal is achieved depends on both the reliability of the software, a good reporting system and corrective actions from multiple parties."
+        },
+        "tranches": {
+          "title": "Build the storage node with \"tranches\"",
+          "text": "Although the content directory is currently small, at some point it's not feasible to expect all storage providers to have full replication of all the content. Tranches would allow storage providers to select a subset of the content directory, suitable to their capabilities."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Acropolis testnet"
+    },
+    "map": {
+      "title": "Acropolis of Athens",
+      "text": "<0>The Acropolis is a citadel on a hill in the heart of Athens.</0> It was also at the heart of Ancient Greece, a powerful civilization and empire. Acropolis is famous for its ancient buildings, architecture, historical significance and is one of the main tourist attractions of Athens. It is on UNESCOs list \"World Heritage Sites\".<1/><1/> We chose the name as we had to scale back our ambitions for the next testnet after some issues with the release of Athens. Thus, Acropolis can be considered a sub-release, despite including some new features not intended for Athens. <1/><1/> <2><0/> Explore previous testnet</2>"
+    }
+  }
+}

--- a/src/locales/zh/alexandria.json
+++ b/src/locales/zh/alexandria.json
@@ -1,0 +1,55 @@
+{
+  "alexandria": {
+    "siteMetadata": {
+      "description": "Explore the Alexandria testnet"
+    },
+    "hero": {
+      "title": "Alexandria Network",
+      "text": "The Alexandria release focuses on important technical updates which will facilitate more efficient future development.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY BABYLON ON"
+    },
+    "modal": {
+      "title": "Alexandria",
+      "text": "There are two sphinxes at the Pompey's Pillar site in Alexandria, Egypt. The sphinxes and associated column are one of Alexandria's most important ancient monuments. <0/><0/> The Alexandria sphinxes should not be confused with the more well-known Great Sphinx located at Giza, just under 200 kilometers south-east of Alexandria."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Alexandria testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Alexandria testnet.",
+      "goals": {
+        "membershipModule": {
+          "title": "Cleaning up the membership module",
+          "text": "Tackling technical debt in the membership module and making it possible to transition to using memberships as the only core actor identifier in the system in future releases."
+        },
+        "substrateVersion": {
+          "title": "Start using Substrate v2.0.0 RC4",
+          "text": "We are transitioning to a new version of Substrate in order to stay up to date with a broad range of enhancements, and to limit how far behind we allow our growing codebase to become."
+        },
+        "networkTesting": {
+          "title": "Enhancing our network testing",
+          "text": "Further maturing our network testing infrastructure to get one step closer to true end-to-end builds that secure an increasingly shorter development cycle."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Alexandria Network"
+    },
+    "map": {
+      "title": "Alexandria",
+      "text": "<0>Alexandria was founded in approximately 331 BC by Alexander the Great.</0> The city was best known for the Lighthouse of Alexandria, one of the Seven Wonders of the Ancient World, as well as its colossal Great Library.<1/><1/> Alexandria was the intellectual and cultural center of the ancient Mediterranean world for much of the Hellenistic age and late antiquity. It was at one time the largest city in the ancient world before being eventually overtaken by Rome.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/zh/antioch.json
+++ b/src/locales/zh/antioch.json
@@ -1,0 +1,42 @@
+{
+  "antioch": {
+    "siteMetadata": {
+      "description": "Explore the Antioch testnet"
+    },
+    "hero": {
+      "title": "Antioch Network",
+      "text": "The Antioch release seeks to patch a chain split bug which unfortunately sabotaged the previous testnet."
+    },
+    "heroCard": {
+      "title": "REPLACED BY SUMER ON"
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Antioch testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Antioch testnet.",
+      "goals": {
+        "substrateVersion": {
+          "title": "Upgrade Substrate Version",
+          "text": "<0>To patch the chain split issue encountered on Babylon we need to update the version of Substrate our network is built on from <1>v2-rc4</1> to <1>v2.0.1</1></0>"
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Antioch Network"
+    },
+    "map": {
+      "title": "Antioch",
+      "text": "<0>Antioch was an ancient Greek city on the eastern side of the Orontes River.</0> The city's position benefited its occupants greatly, particularly on account of such features as the spice trade, the Silk Road, and the Royal Road.<1/><1/>At its height it rivaled Alexandria as the chief city of the Near East. Many also consider the city to be \"the cradle of Christianity\".<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/zh/athens.json
+++ b/src/locales/zh/athens.json
@@ -1,0 +1,59 @@
+{
+  "athens": {
+    "siteMetadata": {
+      "description": "Explore the Athens testnet"
+    },
+    "hero": {
+      "title": "Athens Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "text": "AFTER LAUNCHING 17 / 04 / 19 <0/> THE NETWORK WAS UPGRADED TO <1>ACROPOLIS</1> ON"
+    },
+    "modal": {
+      "title": "Owl of Athena",
+      "text": "<0>In Greek mythology, a little owl (Athene noctua)</0> traditionally represents or accompanies Athena, the virgin goddess of wisdom. Because of such association, the bird — often referred to as the \"owl of Athena\" — has been used as a symbol of knowledge, wisdom, perspicacity and erudition throughout the Western world."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "No specifications was published for Athens."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "media": {
+          "title": "Enable media on the platform",
+          "text": "As a \"user governed media platform\", allowing users to upload and consume and content was a major goal for us."
+        },
+        "memberships": {
+          "title": "Introduce platform memberships",
+          "text": "Although we are building an open blockchain in the sense that users are free to send tokens as they like, the Joystream experience is about having the platform users own, operate and govern the platform. We are agnostic on exactly what parts of the platform will be reserved for members, some actions will require and extra level of screening and accountability."
+        },
+        "storageNode": {
+          "title": "Build and release the storage node",
+          "text": "Although a storage node was built and used to host and distribute the platform content, it had some bugs making it unable to sync between clients and required a hardcoded liaison."
+        },
+        "runtimeUpgrade": {
+          "title": "Upgrade the runtime through a Council vote",
+          "text": "The intention was for Jsgenesis to create a proposal for a <0>runtime upgrade</0> and have the Council vote on it. If the Council reached quorum, the consensus rules of the system would automatically get upgraded in flight. Unfortunately, the <1>Sparta network crashed</1> before we reached this stage, and had to start Athens as a new chain with a new genesis block."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Athens testnet"
+    },
+    "map": {
+      "title": "The city of Athens",
+      "text": "<0>Athens is the capital of Greece.</0> It was also at the heart of Ancient Greece, a powerful civilisation and empire. The city is still dominated by 5th-century BC landmarks, including the Acropolis, a hilltop citadel topped with ancient buildings like the colonnaded Parthenon temple. <1/><1/> We chose the name Athens as, like our previous testnets, Mesopotamia and Sparta, the ancient Athens' historical significance in the development towards modern democracy and the rule of law. <1/><1/> <2> <0/> Explore previous testnet</2>"
+    }
+  }
+}

--- a/src/locales/zh/babylon.json
+++ b/src/locales/zh/babylon.json
@@ -1,0 +1,55 @@
+{
+  "babylon": {
+    "siteMetadata": {
+      "description": "Explore the Babylon testnet"
+    },
+    "hero": {
+      "title": "Babylon Network",
+      "text": "The Babylon release offers improvements which greatly enhance the video publishing and consumption experience.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ANTIOCH ON"
+    },
+    "modal": {
+      "title": "Tower of Babel",
+      "text": "The Tower of Babel story is an origin myth meant to explain why the world's peoples speak different languages.<0/><0/>According to the story, a united human race in the generations following the Great Flood, speaking a single language and migrating eastward, comes to the land of Shinar. There they agree to build a city and a tower tall enough to reach heaven.<0/><0/> God, observing their city and tower, confounds their speech so that they can no longer understand each other, and scatters them around the world."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Babylon testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Babylon testnet.",
+      "goals": {
+        "atlas": {
+          "title": "Launch Atlas 0.1",
+          "text": "This will be the initial release of our content consumption client, aiming to be considerably more effective than the current Pioneer media experience."
+        },
+        "contentDirectory": {
+          "title": "Deploy a new content directory and corresponding working group",
+          "text": "We will be modifying the content directory to allow for a new data model for content, supported by new schemas. We will also make some associated improvements to the Content Curator Working Group."
+        },
+        "hydraNode": {
+          "title": "Deploy first self-hosted Joystream Hydra node only supporting content directory",
+          "text": "Further work on our Hydra framework is required in order to support the new content directory."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Babylon Network"
+    },
+    "map": {
+      "title": "Babylon",
+      "text": "<0>Babylon was the capital city of Babylonia, a kingdom in ancient Mesopotamia, almost 4000 years ago.</0> It was built along the left and right banks of the Euphrates river with steep embankments to contain the river's seasonal floods. <1/><1/> The city is considered to be of great historical and cultural importance. The Hanging Gardens of Babylon were one of the Seven Wonders of the Ancient World and Babylon was also purported to be the site of the Tower of Babel.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/zh/brand.json
+++ b/src/locales/zh/brand.json
@@ -1,0 +1,198 @@
+{
+  "brand": {
+    "siteMetadata": {
+      "title": "Joystream Brand Guide"
+    },
+    "assets": {
+      "logo": "Logo",
+      "logoIcons": "Logo Icons",
+      "descriptiveIcons": "Descriptive Icons",
+      "illustrations": "Illustrations",
+      "systemIcons": "System Icons",
+      "typography": "Typography",
+      "blogPostCovers": "Blog Post Covers",
+      "displayTitle": {
+        "logoPack": "Logo Pack"
+      },
+      "files": "files"
+    },
+    "guides": {
+      "general": {
+        "logo": "Logo",
+        "overview": "Overview",
+        "logomark": "Logomark",
+        "construction": "Construction",
+        "useCases": "Use Cases",
+        "socialIcons": "Social Icons",
+        "forbiddenUses": "Forbidden Uses",
+        "colorPalettes": "Color Palettes",
+        "primaryColors": "Primary Colors",
+        "supportivePallet": "Supportive Pallet",
+        "secondaryPallet": "Secondary Pallet",
+        "iconography": "Iconography",
+        "descriptiveIcons": "Descriptive Icons",
+        "systemIcons": "System Icons",
+        "illustrations": "Illustrations",
+        "patterns": "Patterns",
+        "typography": "Typography",
+        "photography": "Photography",
+        "motion": "Motion",
+        "back": "Back",
+        "more": "More"
+      },
+      "logo": {
+        "experimentation": "Our brand should promote a feeling of experimentation, excitement and building something ethical and dynamic.",
+        "conceptIterations": "Before we agreed on a final logo concept we went through multiple iterations of various concepts. We explored various ideas in depth before settling on the final logo concept."
+      },
+      "logomarkConstruction": {
+        "title": "01. Logomark Construction",
+        "simplePrinciples": "In the end we came up with a logomark that combines several simple principles which translate well to the voice of the brand.",
+        "combination": "Our logomark is a combination of the letter J (to represent the name Joystream) and three parallel stripes that are a representation of streaming data and the flow of information and technology.",
+        "image": {
+          "logomarkDescription": "Logomark's exclusion zone is equal to the blue square height (marked as 5a in the diagram)."
+        }
+      },
+      "logoConstruction": {
+        "title": "02. Logo Construction",
+        "combination": "The Joystream logo is a combination of the logomark and dedicated typography that was designed to be the best link between the logomark and what Joystream stands for. It is firm and technical but shows plasticity and sense of a structure.",
+        "horizontalLockup": "Horizontal Lockup",
+        "verticalLockup": "Vertical Lockup"
+      },
+      "logoUseCases": {
+        "title": "03. Logo Use Cases",
+        "originalForm": "The Joystream logo is primarly used in its original form on white backgrounds but it can also be used in its complimentary forms if necessary. Examples show such use cases below.",
+        "safeUse": "The smallest safe use",
+        "visualPresentation": "In order to ensure the best visual presentation of the logo, it is best offered in sizes between <0>200 and 500+px</0> width on digital devices.",
+        "horizontalNarrow": "The Joystream logo should never be narrower than 100px in digital or 20mm in print horisontal lockup.",
+        "verticalNarrow": "Vertical lockup should never be narrower than 70px in digital or 15mm in print."
+      },
+      "logoSocialIcons": {
+        "title": "04. Social Icons",
+        "icon": "In cases when the Joystream brand has already been established we can simply use the icon on its own. While the icon can exist without the wordmark, the wordmark should never exist without the icon."
+      },
+      "logoForbiddenUses": {
+        "title": "05. Forbidden uses of the logo",
+        "rules": "The logotype and the icon must follow certain rules and there are general cases of use that should be avoided at all costs! In order to preserve the brand voice remember to avoid examples such as the following:"
+      },
+      "colorOverview": {
+        "combine": "Our brand colors combine three primary colors: black, white and blue. They define the mood and present brand values including:",
+        "example": "Stability, Trust, Freedom, Responsibility, Loyalty, Wisdom, Confidence and Intelligence"
+      },
+      "primaryColors": {
+        "title": "01. Primary Colors",
+        "blackAndBlue": "Our primarly used colors are black and Joystream blue, a distinctive color that helps to put focus and draw attention. The color white can be deployed in order to calm, provide clarity and offer improved readability.",
+        "blueGrey": "One additional color to combine with the three primary colors is blue tinted grey, its purpose is comparable to that of white but it also gives a good amount of contrast to the existing white elements where necessary."
+      },
+      "supportiveColors": {
+        "title": "02. Supportive Color Palette",
+        "purpose": "Our supportive palette serves the purpose of convenience and usability. This pallete provides a comprehensive range of different shades of primary colors and can be utilised in many different ways depending on requirements."
+      },
+      "secondaryColors": {
+        "title": "03. Secondary Color Palette",
+        "states": "These are further colours that can represent certain states of the network, they can stand for an error, success, warning and more."
+      },
+      "iconsOverview": {
+        "text": "Icons can be divided into two groups with different purposes. Descriptive icons are a substitute for illustrations and system icons are a purely functional part of the interface.",
+        "typeDescriptive": "01. Descriptive",
+        "typeSystem": "02. System"
+      },
+      "descriptiveIcons": {
+        "title": "01. Descriptive Icons",
+        "comprehensiveStyle": "Joystream iconography is a custom, comprehensive icon style that helps in explaining certain complex topics in a simple, digestable manner.",
+        "symbolic": "They are not always very direct and often carry a symbolic meaning but they help to emphasize important elements.",
+        "characteristicFeatures": "Characteristic features of the descriptive icons include paralell striped fills. They are a translation of logo stripes and represent shadows.",
+        "angle": "Lines have an angle of 45° they should have 2px girth and 8px space between them at 100% scale.",
+        "outlines": "Icons are drawn using outlines of 12px width at 100% scale, they have square linecaps and can have various sizes depending on the composition.",
+        "fit": "Icons at 100% scale should fit into a box of 800x500px."
+      },
+      "systemIcons": {
+        "title": "02. System Icons",
+        "basicStyle": "System icons in their basic style combine two colors: black and Joystream Blue. Their purpose is to represent certain actions on the website or platform. They are readable even in small sizes down to 18x18px.",
+        "strokes": "System Icons are drawn using 2px strokes with square linecaps on a 24px grid frame.",
+        "subtleAccents": "Where possible, icons should have subtle blue accents representing no greater than 40% of the whole.",
+        "types": "Types of system icons",
+        "fourTypes": {
+          "text": "We distinguish four types of system icons and they should be used preferably in their basic style but can be used interchangeably where neccessary.",
+          "basic": "Basic style",
+          "blue": "Blue outlines",
+          "white": "White outlines",
+          "full": "Full style"
+        }
+      },
+      "illustrations": {
+        "overview": "Joystream Illustrations are symbolic representation of important concepts within the Joystream project. These might include a a new testnet, a particular role on the network or any other equally significant subject.",
+        "complex": "They can be quite visualy complex despite using only three colors and no gradients.",
+        "patterns": "Illustrations will often be combined with patterns and in the case of putting them on a blue background, the outline of the illustration can be changed to Joystream Blue in order to create a good color balance between patterns and the background.",
+        "distinctive": "Illustrations should be simple enough to be distinctive even in smaller resolutions down to 300x300px.",
+        "adequateDetail": "The amount of detail should be adequate to what the illustration represents, in most cases they should be deployed at sizes no smaller than 500x500px."
+      },
+      "patterns": {
+        "translation": "Patterns are close translation of the logomark (J) into variants of geometrical shapes representing the flow of information, technology and Joystream's experimental brand personality.",
+        "supportTool": "They were introduced as a support tool to make certain elements stand-out, to build mood and as an inherent element of the visual identity of the brand.",
+        "sixPieces": "Patterns visually consist of six different pieces that can be rotated by 90 degrees in any direction and should always have the dimensions of a perfect square.",
+        "oneCommonVertex": "They should also have at least one common vertex when they touch. They do not always have to touch and when they don’t, space between pieces should always be equal to its’ width/height or the value multiplied.",
+        "howToUse": "How to use patterns",
+        "oneOfFive": "Patterns can use one of five different colors depending on what background is used beneath and what their main purpose is in a given situation.",
+        "density": "Depending on the situation these can be used more or less densely.",
+        "inUse": "Patterns in use - examples"
+      },
+      "typography": {
+        "overview": "Our typefaces are simple, comprehensive and modern. This is a reflection of our brand and our voice. We chose the appropriate typeface weights from PX Grotesk (regular, bold) and Inter family for specific touchpoints and to create clear hierarchies of information and messages.",
+        "backup": "If either two typefaces are impossible to use please choose Arial Regular. This may be required across PC operating systems or electronic internal documents or in diferent offices worldwide. Don’t use Arial for any print materials.",
+        "sample": "The following is a sample of an ideal font stack using PX Grotesk for headlines and larger pull quote text and Inter UI for paragraph and call-to-action text."
+      },
+      "photography": {
+        "overview": "Photographs should be relevant to the topic they are describing but they shouldn’t be limited only to technology. Joystream is much more than just technology; it is unifying, fresh and joyful. Imagery should convey this mood to users.",
+        "howToUse": "How to use photography",
+        "variety": "Since Joystream is a unique and experimental project it provides a wide variety of the topics which might be  associated with it in terms of photography. It is highly technical especially now when we are in the community building phase, so good deal of the photographs will be tech related.",
+        "consistency": "One way to make sure the photographs are consistent is to use them in dual tones deriving from branding colors. For that purpose we can use a handy tool to consistently change images to dual tones as described below.",
+        "consistentDuotones": "The link below allows you to create consistent duotones with any photography after inputing the proper two Joystream colours.",
+        "mood": "The mood that photos convey is extremely important. It should by all means give a feel of building trust, community and joy. Photographs should show good amount of diversity as it is meant to be for an extremely wide variety of users. They don’t have to be used in dual tones but it is best if they are not \"screaming\" with colours.",
+        "inUse": "Photography in use - examples"
+      },
+      "motion": {
+        "subtitle": "Joystream is an experimental and exciting platform and its motion should be too.",
+        "rules": "General rules for motion can be described with a few simple principles: smooth transitions, dynamic but fluid motion and good amount of easing at the keyframes. This combination should provide a consistent and flexible animation style to cover most of the use cases.",
+        "notLimiting": "Guides should be by no means limiting, they should only serve the purpose of providing consistency for animations."
+      }
+    },
+    "story": {
+      "header": {
+        "title": "Joystream Brand Story",
+        "description": "Joystream offers a modern, experimental solution to the problem of accountable governance in digital media. <0>Our objective is to build a user-governed video platform with a strong sense of community and freedom.</0>",
+        "buttonText": "Manifesto"
+      },
+      "website": {
+        "title": "The Website",
+        "linkText": "Visit the Website"
+      },
+      "description": {
+        "header": "Our brand identity consists of few key visual elements: our logo, typeface, illustrations, patterns, colour palette and iconography.",
+        "meaningfulRole": "Each of these elements has a meaningful role in brand identity as established in the guidelines. But combining all of these components builds much more than just a visual experience.",
+        "powerfulTool": "Joystream branding is a powerful tool for communication with all of its users throughout their whole experience.",
+        "experimental": "Fundamentally, our effort is an experimental one; we do not have all the answers, and we want to be honest about that in our communication.",
+        "empowering": "We are not promising cheaper, faster or nicer, like one typically would when selling a consumer widget or service. Instead we have hope that we can build something more empowering and accountable through our process of experimentation.",
+        "governance": "Lastly, at the core of our vision is governance, so what we are building is never finished; we are only constructing the first piece. It is a dynamic effort we hope communities will carry forward in amazing ways, we are just providing the first set of tools.",
+        "footer": "For the reasons outlined above, our brand should carry this feeling of experimentation, excitement and building something ethical and dynamic."
+      },
+      "logo": {
+        "title": "We want to free the media, inspire people and connect them using platform",
+        "uniqueness": "Creating the Joystream brand proved to be challenging due to its uniqueness and the fact that it is continually evolving.",
+        "requirements": "Not only did we have to take into account a very wide and diverse user base but also we had to create a brand that will be futureproof and flexible enough to cover both the existing and upcoming requirements of the project.",
+        "branding": "Joystream branding itself is quite metaphoric and symbolic, often referring to symbolism of ancient cities, culture, arts and philosophies.",
+        "challenge": "The challenge was to combine it with very modern and complex technologies."
+      },
+      "explanation": {
+        "title": "Explaining the Brand",
+        "balance": "Our new branding is about finding good balance between a very simplistic tone of communication with the symbolism and complexity of modern world problems and technologies.",
+        "patterns": "Our branding uses mosaic, geometrical patterns and shapes combined with explicit colours and symbolic  illustrations.",
+        "style": "We also deploy descriptive icons in combination with simple glyph style system icons and an experimental  illustration style."
+      }
+    },
+    "button": {
+      "text": {
+        "downloadLogo": "Download Logo"
+      }
+    }
+  }
+}

--- a/src/locales/zh/constantinople.json
+++ b/src/locales/zh/constantinople.json
@@ -1,0 +1,51 @@
+{
+  "constantinople": {
+    "siteMetadata": {
+      "description": "Explore the Constantinople testnet"
+    },
+    "hero": {
+      "title": "Constantinople Network",
+      "text": "The Constantinople testnet introduces an improved proposals system and fiat-backed token model for participant compensation.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY ALEXANDRIA ON"
+    },
+    "modal": {
+      "title": "Constantinople",
+      "text": "The Column of Constantine, also known as the Burnt Stone or the Burnt Pillar, is a Roman monumental column constructed on the orders of the Roman emperor Constantine the Great in 330 AD. It commemorates the declaration of Byzantium as the new capital city of the Roman Empire."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Constantinople testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Constantinople testnet.",
+      "goals": {
+        "proposalSystem": {
+          "title": "Launch a new proposal system",
+          "text": "The constantinople testnet is built around the introduction of a proposal system that strengthens the governance structure of the platform, shifting the day to day responsibility of monitoring the network and allocating resources to voters and the council."
+        },
+        "tokenModel": {
+          "title": "Introduce a fiat-backed token model",
+          "text": "Constantinople introduces a new incentive structure, with a fiat (USD) pool backing the testnet tokens, setting up a more realistic economic system for the platform."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Constantinople Network"
+    },
+    "map": {
+      "title": "Constantinople",
+      "text": "<0>Constantinople was the capital city of the Eastern Roman Empire during the fourth century.</0> It was famed for its massive and complex defences as well as its architectural masterpieces and opulent aristocratic palaces. As was the case with the city, we hope our Constantinople testnet will be a worthy successor to Rome.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/zh/dashboard.json
+++ b/src/locales/zh/dashboard.json
@@ -1,0 +1,17 @@
+{
+    "dashboard" : {
+        "siteMetadata" : {
+            "title" : "Live Dashboard",
+            "description" : "Data compiled from current Pioneer and Atlas instances and visualized through charts."
+        },
+        "title" : "Joystream Dashboard",
+        "subtitles" : {
+            "videos" : "Videos",
+            "channels" : "Channels",
+            "users" : "Users",
+            "posts" : "Posts",
+            "threads" : "Threads"
+        },
+        "amount" : "Amount"
+    }
+}

--- a/src/locales/zh/founding-members.json
+++ b/src/locales/zh/founding-members.json
@@ -1,0 +1,171 @@
+{
+  "foundingMembers": {
+    "general": {
+      "foundingMembers": "Founding Members",
+      "nonFoundingMembers": "Non-Founding Members",
+      "directScore": "Direct Score",
+      "referralScore": "Referral Score",
+      "totalScore": "Total Score",
+      "inducted": "Inducted",
+      "member": "Member",
+      "backButton": "Back to Program page",
+      "before": "Before",
+      "account": "Account",
+      "next": "Next",
+      "howItWorks": "How it works.",
+      "inputPlaceholder": "e.g. joedoe",
+      "inductionDate": "Induction Date",
+      "joinOurDiscord": "Join our Discord"
+    },
+    "scoringPeriod": {
+      "title": "Current scoring period",
+      "currentNumber": "Current period number",
+      "ends": "ENDS",
+      "endedOn": "ENDED ON",
+      "weeks": "WEEKS",
+      "days": "DAYS",
+      "hours": "HOURS",
+      "minutes": "MINUTES",
+      "submitSummary": "Submit Summary",
+      "periodAnnouncement": "Period Announcement",
+      "announcement": "Announcement"
+    },
+    "landing": {
+      "siteMetadata": {
+        "title": "Founding Members",
+        "description": "Information and data regarding the new Founding Members Program of the Joystream platform."
+      },
+      "hero": {
+        "title": "Joystream Founding Member Program",
+        "text": "Founding Members are highly effective project contributors awarded JOY tokens in the mainnet genesis block.",
+        "imageAlt": "founding members visual"
+      },
+      "list": {
+        "currentMembers": "Current founding members",
+        "newMembers": "New founding members",
+        "iconAlt": "icon of founding member"
+      },
+      "benefits": {
+        "title": "What is the Founding <0/> Member Program <0/> and why does it exist?",
+        "currentlyBuilding": "While Jsgenesis is the team currently building the technology behind the Joystream project, we will not be around forever, and we are instead entrusting the future operation of the Joystream DAO to our community members.",
+        "foundingMembers": "The Founding Member Program formally allocates JOY tokens among some of our highest quality community members in recognition of their contributions to the project and ensures that a sufficiently large, effective and motivated community of users is ready to occupy all the different roles required to run, evolve and grow the platform on mainnet.",
+        "benefits": "Benefits",
+        "benefitsAlternate": "Benefits of becoming a founding member",
+        "payout": {
+          "title": "Tokens",
+          "text": "allocated tokens in the genesis block of the Joystream mainnet as a result of high quality participation and recruiting other participants"
+        },
+        "membership": {
+          "title": "Membership Status",
+          "text": "special status membership assigned in genesis block, which will have a visually distinguished presentation in Pioneer and other products"
+        },
+        "avatar": {
+          "title": "Handcrafted Avatar",
+          "text": "receive a handcrafted premium membership avatar and be honoured on the official project website and social media leading up to mainnet"
+        },
+        "itemImageAlt": "benefit item"
+      },
+      "takePart": {
+        "title": "How to participate in the program",
+        "introduceYourself": {
+          "text": "Introduce yourself on Discord.",
+          "altText": "Introduce yourself in our Discord."
+        },
+        "contribute": {
+          "text": "Make contributions to the project.",
+          "contributions": "<0><0>training other participants</0><0>writing blog posts and documentation</0><0>creating and publishing new video content</0><0>participating in platform roles on the testnet</0><0>finding and reporting bugs and errors</0><0>completing official bounties</0><0>creative and design work</0></0>"
+        },
+        "report": "Regularly report your activity.",
+        "earnPoints": "Earn leaderboard points.",
+        "becomeFM": "Become a founding member!",
+        "buttonText": "Join Discord",
+        "excluded": "Countries that are excluded from that program: ",
+        "usFlagAlt": "us flag icon",
+        "tokensAlt": "two tokens"
+      },
+      "keyMetrics": {
+        "title": "Key metrics for the program",
+        "initialTokenPool": "size of initial token pool",
+        "numberOfFM": "number of founding members",
+        "numberOfCandidates": "number of founding member candidates",
+        "leaderboards": "Leaderboards",
+        "foundingMembersButton": "All Founding Member Scores",
+        "regularMembersButton": "All Regular Member Scores",
+        "fullProgramRules": "Read the full program rules"
+      },
+      "cta": {
+        "title": "Discuss the program",
+        "joinDiscord": "Begin your founding member journey by joining our Discord group and requesting your first testnet tokens.",
+        "askQuestions": "Here you can also ask question about many aspects of the program and find out the areas where you can contribute right away.",
+        "joinNow": "Join now",
+        "imageAlt": "founding members visual"
+      },
+      "disclaimer": {
+        "title": "Disclaimer",
+        "text": "This disclaimer applies to the webpage accessible at <0>www.joystream.org/token</0> as well as all other webpages, digital services or applications published by Jsgenesis (the “Company”). The disclaimer also applies to any material published by Company in any other format in connection with the JOY token (the “Token”). Publications made by Company and all information contained within them are not directed at or intended for use by any person resident or located in any jurisdiction where (1) the distribution of such information is contrary to the laws of such jurisdiction; or (2) such distribution is prohibited without obtaining the necessary licenses or authorizations by the relevant branch, subsidiary or affiliate office of Company and such licenses or authorizations have not been obtained. Company does not provide investment, legal or tax advice and nothing herein should be construed as being financial, legal, tax or other advice. Unless specifically stated otherwise, all price information is indicative only. No representation or warranty, either express or implied, is provided in relation to the accuracy, completeness or reliability of the materials, nor are they a complete statement of the securities, markets or developments referred to herein. The materials should not be regarded by recipients as a substitute for the exercise of their own judgment. All information and materials published, distributed or otherwise made available by Company in relation to Token are provided for informational purposes, for your non-commercial, personal use only. No information or materials published by Company constitutes a solicitation, an offer, or a recommendation to buy or sell any investment instruments, to effect any transactions, or to conclude any legal act of any kind whatsoever."
+      }
+    },
+    "leaderboards": {
+      "siteMetadata": {
+        "title": "Founding Members Leaderboards"
+      },
+      "title": "Leaderboard"
+    },
+    "form": {
+      "siteMetadata": {
+        "title": "Founding Members Form"
+      },
+      "title": "Submit activity summary",
+      "progressItem": {
+        "accountInfo": "Account info",
+        "keyFile": "Key file",
+        "summary": "Summary",
+        "acceptTerms": "Accept terms & conditions",
+        "acceptTermsShort": "Terms & cond."
+      },
+      "membership": {
+        "membershipHandle": "Membership handle",
+        "avatarAlt": "founding member avatar"
+      },
+      "json": {
+        "exportedAccount": "Exported account with key",
+        "howToExport": {
+          "link": "How to export your key?",
+          "title": "How to export your account with key:",
+          "text": "In the <0>Pioneer application</0> click the <1>My Keys</1> tab and then click the ellipsis (three dots) button on the Key which you would like to use. Then click <1>Create a backup file for this account</1>. Enter your password (if applicable) and the JSON will be downloaded."
+        },
+        "fileFormat": "Accepted file format: .json"
+      },
+      "keybaseAndText": {
+        "keybaseHandle": "Keybase handle",
+        "documentWithSummary": "Document with the summary",
+        "howToPrepare": {
+          "link": "How should I prepare it?",
+          "alternateLink": "How should I do it?",
+          "title": "How to prepare it:",
+          "text": "Your activity summary should describe in as much detail as possible your recent contributions to the success of the platform. Try to separate out each contribution into a separate paragraph or bullet point for ease of processing."
+        },
+        "fileFormat": "Accepted file format: .txt",
+        "password": "Password",
+        "pleaseEnterPassword": "Please enter your password!"
+      },
+      "termsAndConditions": {
+        "title": "Read and accept terms and conditions",
+        "text": "<0>Term</0><1>The Joystream Founding Member Program was formally launched during February 2021. The program will stop accepting new submissions (activity summaries) and awarding further leaderboard points approximately one month in advance of the mainnet launch, on the snapshot date, yet to be confirmed.</1><2><0>Our current target for mainnet launch is during Q4 2021, though this is subject to change.</0></2><0>Eligibility</0><1>The program is open to everyone over the age of 18 who are not U.S. persons. </1><1>To be formally admitted to the program you will be contacted and screened by a Jsgenesis representative once your community contributions have met our internally determined threshold for admission.</1><2>The formal admission of new Founding Members to the program will take place at the end of scoring periods (the dates of which are published on our website). Each scoring period currently lasts two weeks.</2><0>Communication</0><1>We will publish further public updates about the program through our regular communication channels, including our Official Discord Channel, the Joystream Newsletter, the official GitHub repo for the program (github.com/joystream/founding-members) and on our website (www.joystream.org), and blog (blog.joystream.org).</1><2>Any private or sensitive information about your participation in the program will be communicated via Keybase or some other previously agreed contact method.</2><0>Token Allocation Formula</0><1>Once officially awarded with Founding Member status, you will be automatically assigned 0.02% of the mainnet genesis token supply. The rest of your token allocation will be calculated based on your proportional share of leaderboard points among all Founding Members.</1><2>Since the current program provides a token pool of 15%, this 15% will be made up of claims of the default 0.02% by each participant, and the remaining allocation not already claimed under this rule will be distributed proportionally based on the relative share of total leaderboard points for each Founding Member.</2><0>Reward Policy</0><1>Points have no intrinsic value and when assigned to users with the Founding Member status they only represent a partial claim on an as yet undetermined quantity of mainnet JOY tokens. In the case of bad faith activity (see below), leaderboard/founding member points can be voided at any time.</1><2>Participants should also be aware that tokens allocated for mainnet may include some vesting period or \"locks\", that restricts what they can be used for some period of time.</2><0>Eviction Policy</0><2>Any platform member who participates in fraudulent or bad faith activity is liable to be expelled from the leaderboards and Founding Member program, with all associated token claims voided.</2><0>Account and Key Security</0><1>Your leaderboard/founding member points are yours alone and are non-transferrable. You must keep your account and any private keys associated with your membership of the Founding Member program safe and engage in sensible digital security practices.</1><1>Keys with associated Founding Member token claims must not be transferred to anyone else under any circumstances. Where this occurs, points or token claims may be voided (see above).</1><2>Tokens can only be allocated to addresses under your control. You may be required to sign a message proving you own the private keys to any addresses you provide.</2><0>Activity Reporting</0><1>You cannot claim for the same activity on more than one occasion (i.e. across more than one summary) in order to be awarded the same points twice. If this does occur it is liable to be deemed bad faith and may result in your eviction from the program.</1><1>All activity must be reported within 30 days of taking place. Contributions recorded outside of this window will not qualify for rewards. For this reason it is very important to submit regular summaries.</1><1>Once you have submitted your activity up to and including a certain date, you can no longer submit activity from before this date.</1><2>When reporting contributions, the correct format for summary submissions should be observed.</2><0>Updates To These Rules</0><1>Jsgenesis reserves the right to update the rules of the program at any time, for any reason.</1><1>If serious flaws in the structure of the program are discovered, Jsgenesis reserves the right to announce that after a future scoring period, the \"season\" is concluded, and a new scheme will apply to following seasons, thus resetting \"scores\". In such an event, a \"slice\" of the pool, set by Jsgenesis discretion, will be allocated in accordance with existing rules. The remainder will be transferred to new \"seasons\".</1><1>Jsgenesis reserves the right not to honour any aspect of this agreement due to legal considerations.</1>"
+      },
+      "success": {
+        "title": "Thank you for submitting your summary, we have received it successfully.",
+        "text": "We will process the information contained within it shortly and award leaderboard points for qualifying contributions."
+      },
+      "error": {
+        "noSuchAccount": "No such account exists. Try again!",
+        "incorrectPassword": "Password is incorrect, please try again!",
+        "fileFormat": "Wrong file format! Please try again or check our tips how to export it.",
+        "jsonWrongAccount": "Json file doesn't correspond to account given!",
+        "faultyJson": "Json file has incomplete/incorrect components. Try exporting your account again!"
+      },
+      "dropFile": "Drop you file here or <0>browse files</0>",
+      "uploadFile": "Upload file"
+    }
+  }
+}

--- a/src/locales/zh/general.json
+++ b/src/locales/zh/general.json
@@ -1,0 +1,135 @@
+{
+  "joystream": "Joystream",
+  "button": {
+    "getStarted": {
+      "text": "Start earning",
+      "altText": "Join & start earning"
+    },
+    "download": "Download",
+    "close": "Close",
+    "accept": "Accept",
+    "openDiscord": "Open Discord",
+    "learnMore": "Learn More",
+    "gettingStarted": "Getting Started"
+  },
+  "rolesData": {
+    "validator": "Validator",
+    "council": "Council",
+    "councilMember": "Council Member",
+    "storageProvider": "Storage Provider",
+    "contentCreator": "Content Creator",
+    "contentCurator": "Content Curator",
+    "discoveryProvider": "Discovery Provider",
+    "bandwidthProvider": "Bandwidth Provider",
+    "builder": "Builder",
+    "storageLead" : "Storage Lead",
+    "contentLead" : "Content Lead"
+  },
+  "siteMetadata": {
+    "title": "Joystream: The video platform DAO"
+  },
+  "colors": {
+    "joystreamBlue": "Joystream Blue",
+    "white": "White",
+    "joystreamGrey": "Joystream Grey",
+    "black": "Black"
+  },
+  "CMYK": "CMYK",
+  "RGB": "RGB",
+  "HEX": "HEX",
+  "orderedNumbers": {
+    "one": "01.",
+    "two": "02."
+  },
+  "numbers": {
+    "one": "1",
+    "two": "2",
+    "three": "3",
+    "four": "4",
+    "five": "5",
+    "six": "6",
+    "seven": "7"
+  },
+  "roleCard": {
+    "migration": "At migration, {{numberOfUsers}} (max) had this role",
+    "current": "{{numberOfUsers}} run this role on Antioch",
+    "most": "At most, {{numberOfUsers}} users occupied this role",
+    "new": "NEW"
+  },
+  "heroCard": {
+    "active": "Network announced",
+    "error": "Network down",
+    "info": "Network replaced",
+    "finished": "Network live"
+  },
+  "dateCounter": {
+    "week": "week",
+    "weeks": "weeks",
+    "day": "day",
+    "days": "days",
+    "hour": "hour",
+    "hours": "hours",
+    "minute": "minute",
+    "minutes": "minutes",
+    "second": "second",
+    "seconds": "seconds",
+    "month": "month",
+    "months": "months",
+    "year": "year",
+    "years": "years",
+    "timeToLaunch": "Time to launch",
+    "launchedOn": "Launched on"
+  },
+  "sidebar": {
+    "activeRoles": "Active roles",
+    "upcomingRoles": "Upcoming roles",
+    "viewAllRoles": "View all Roles"
+  },
+  "navbar": {
+    "product": "Product",
+    "atlas": "Atlas",
+    "pioneer": "Pioneer",
+    "community": "Community",
+    "brandStory": "Brand Story",
+    "brandGuides": "Brand Guides",
+    "downloadAssets": "Download Assets",
+    "about": "About"
+  },
+  "footer": {
+    "title": "Stay up to date",
+    "alternateTitle": "Get notified",
+    "subtitle": "Don't worry about spam! Keep track of all important updates",
+    "inputPlaceholder": "Email Address...",
+    "joinNewsletter": "Join the newsletter",
+    "github": {
+      "whitepaper": "Whitepaper",
+      "repository": "Repository"
+    },
+    "usefulLinks": {
+      "title": "Useful links",
+      "hiring": "We are hiring!",
+      "brandGuidance": "Brand guidance"
+    },
+    "followUs": "Follow us"
+  },
+  "pages": {
+    "blog": "Blog",
+    "manifesto": "Manifesto",
+    "roles": "Roles",
+    "token": "Token",
+    "hydra": "Hydra",
+    "foundingMembers": "Founding Members",
+    "leaderboards": "Leaderboards",
+    "scoringForm": "Scoring form",
+    "overview": "Overview"
+  },
+  "socials": {
+    "twitter": "Twitter",
+    "github": "GitHub",
+    "discord": "Discord"
+  },
+  "cookiesNotice": {
+    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "findOutMore": "Find out more ›"
+  }
+}

--- a/src/locales/zh/get-started.json
+++ b/src/locales/zh/get-started.json
@@ -1,0 +1,56 @@
+{
+  "getStarted": {
+    "siteMetadata": {
+      "title": "Getting Started",
+      "description": "Learn how to contribute and participate to the Joystream project"
+    },
+    "hero": {
+      "title": "How to Contribute and Participate",
+      "subtitle": "Read more about the current ways you can add value to the project and earn rewards for doing so.",
+      "buttonText": "View opportunities",
+      "imageAlt": "getting started hero"
+    },
+    "howToStart": {
+      "title": "How to start",
+      "discord": "Join our Discord",
+      "tokens": "Receive free testnet tokens",
+      "membership": "Create membership on-chain",
+      "opportunities": "Pick one of the opportunities below"
+    },
+    "opportunities": {
+      "title": "Opportunities",
+      "bounties": {
+        "title": "Bounties",
+        "text": "Bounties are long running tasks which anyone can attempt to tackle in a exchange for some reward. They are created either by Jsgenesis, or by the Council.",
+        "imageAlt": "money pouch"
+      },
+      "bountiesCarousel": {
+        "all": "All",
+        "coding": "Coding",
+        "design": "Design",
+        "marketing": "Marketing",
+        "research": "Research",
+        "contentCreation": "Content Creation"
+      },
+      "roles": {
+        "title": "Roles",
+        "text": "Our current testnet also allows you to participate in some of the platform roles which will be available on mainnet.<0/><0/>Participation in these roles is rewarded in tJOY (our testnet token) which is backed by fiat reserves at Jsgenesis and redeemable for bitcoin cash.",
+        "imageAlt": "masks"
+      }
+    },
+    "activeRoles": {
+      "title": "Active roles on the current testnet",
+      "validatorText": "A Validator is an actor which checks the validity of newly constructed blocks, proposes new blocks and participates in the consensus process for committing new block to the chain. Validators are typically paid a fixed amount for each block produced. This role has a purpose very similar to that of the miners in the Bitcoin blockchain.",
+      "councilMemberText": "Council Members are elected by stakeholders in the system to act in the long-term interest of the platform. They are responsible for allocating resources, and hiring working group leads to run the platform's day-to-day operations. This is done through the proposal system, allowing any user to submit suggestions for changing the platform in some way.",
+      "storageProviderText": "There are critical platform assets that do not live on the blockchain, such as content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enable uploading and downloading of such data. The Storage Provider is involved this activity, specifically by storing large quantities of data.",
+      "storageLeadText": "The Storage Lead is hired directly by the Council through the proposals system and is dedicated to the hiring, firing and wider management of Storage Providers on the network.",
+      "contentCuratorText": "Content Curators are responsible for monitoring the publishing of new content into the content directory, and responding to reports about contested publications. They must also update information on content to ensure it is accurate, with correct metadata. Collaborating with Builders to improve tools and user-facing experiences is another significant part of the role.",
+      "contentCreatorText": "Content Creators are those platform participants who have decided to contribute their own original (or third-party licensed) content to the platform. There are no direct incentives for this informal role at this time, though effective contributors are very likely to be rewarded through the Founding Member Program.",
+      "contentLeadText": "The Council has the power to appoint a Content Curator Lead for the network who can hire further Content Curators. The Content Lead also decides on priorities for curation. If necessary, upon discussing with the council, the Lead can also decide to fire curators who are not performing their jobs adequately."
+    },
+    "roleCard": {
+      "overview": "Overview",
+      "buttonText": "Check details on GitHub"
+    }
+  }
+}

--- a/src/locales/zh/hydra.json
+++ b/src/locales/zh/hydra.json
@@ -1,0 +1,98 @@
+{
+  "hydra": {
+    "siteMetadata": {
+      "title": "Hydra - A Substrate query node framework",
+      "description": "Inspired by The Graph, it gives a smooth way to provide powerful GraphQL queries to app developers over your Substrate blockchain state and history."
+    },
+    "hero": {
+      "title": "Hydra - A Substrate query node framework",
+      "text": "Inspired by The Graph, it gives a smooth way to provide powerful GraphQL queries to app developers over your Substrate blockchain state and history."
+    },
+    "value": {
+      "title": "We make it simple",
+      "subtitle": "Building great apps talking directly to a Substrate full node is impossible, and simply trying is slow and hard.",
+      "values": {
+        "slowFetching": {
+          "title": "Slow Fetching",
+          "text": "Doing multiple read operations across multiple block heights is often required, and the pure latency of fetching the data is very bad. Some reads may depend on the result of prior ones, which results in sequential reads, which is even slower."
+        },
+        "slowProcessing": {
+          "title": "Slow Processing",
+          "text": "The client has to do all the work of filtering, sorting, paginating or otherwise computing on the resulting data, and this takes time, resulting in a slow client experience and CPU load on the user device."
+        },
+        "complexClient": {
+          "title": "Complex Client",
+          "text": "The fetching and processing logic is reproduced in all apps, and adds to the complexity of application development."
+        },
+        "noSearch": {
+          "title": "No Search",
+          "text": "Your chain may have transactional or state commitments to free-text data, but doing real full-text search client-side is not an option."
+        },
+        "overFetching": {
+          "title": "Over-Fetching",
+          "text": "You cannot select the data you want, you have to read full state objects as they are, wasting both connection and full node capacity."
+        },
+        "costlyNodes": {
+          "title": "Costly Archival Nodes",
+          "text": "User requests which involve multiple read operations. To fetch a consistent dataset, you will often have to read at some specific block height, as always reading at the tip can break atomicity. This means such read requests will depend on the full node being archival. As your user base scales, that will become a very costly infrastructure."
+        }
+      }
+    },
+    "snippet": {
+      "title": "Powerful queries in GraphQL",
+      "subtitle": "Provide application developers a powerful GraphQL API for your blockchain state and history"
+    },
+    "features": {
+      "title": "Hydra Features",
+      "values": {
+        "fullTextSearch": {
+          "title": "Full-text Search",
+          "text": "Decorate any number of String fields in the input schema with @fulltext(query: \"myquery\") to seach across different fields and entities."
+        },
+        "filtering": {
+          "title": "Filtering",
+          "text": "Any entity field can be used for OpenCRUD filtering"
+        },
+        "pagination": {
+          "title": "Pagination",
+          "text": "Each GraphQL query supports pagination out-of-the-box"
+        },
+        "ordering": {
+          "title": "Ordering",
+          "text": "Order by any primitive field"
+        },
+        "polymorphism": {
+          "title": "Polymorphism",
+          "text": "Native support of GraphQL interfaces and type inline fragments"
+        },
+        "algebraicTypes": {
+          "title": "Algebraic Types",
+          "text": "Construct rich and queriable algebraic types with @variant directive"
+        }
+      }
+    },
+    "videoTitle": "Play a video tutorial",
+    "getStarted": {
+      "title": "Get started with Hydra now!",
+      "subtitle": "Use the following links to connect with us and find out even more.",
+      "links": {
+        "documentation": {
+          "name": "Documentation",
+          "link": "Documentation"
+        },
+        "githubRepository": {
+          "name": "Github Repository",
+          "link": "Github repo"
+        },
+        "kusamaPlayground": {
+          "name": "Kusama Playground",
+          "link": "Go to the Playground"
+        },
+        "discord": {
+          "name": "Discord",
+          "link": "Go to the Channel"
+        }
+      }
+    }
+  }
+}

--- a/src/locales/zh/landing.json
+++ b/src/locales/zh/landing.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "siteMetadata": {
+      "description": "Joystream is a video platform controlled, owned, and operated by its users."
+    },
+    "hero": {
+      "title": "The video platform DAO",
+      "subtitle": "Joystream is a video platform controlled,<0/> owned, and operated by its users",
+      "metrics": {
+        "mainTitle": "Testnet Metrics",
+        "titles": {
+          "participationPayout": "Participation Payout",
+          "activeValidators": "Active Validators",
+          "blockHeight": "Block Height",
+          "memberships": "Memberships"
+        }
+      }
+    },
+    "becomeFM": {
+      "subtitle": "Our brand new and unparalleled community token distribution scheme",
+      "title": "Become a Founding Member to earn mainnet tokens and influence the development of the platform.",
+      "alternateTitle": "Become a Founding member and have a tangible impact on the development of our platform.",
+      "link": "Learn more about our generous program"
+    },
+    "whatWeDo": {
+      "subtitle": "Our motivation for building the Joystream protocol",
+      "title": "We call for an arrangement where media platforms are accountable to the people they impact.",
+      "link": "Read our manifesto"
+    },
+    "whyYouShouldJoin": {
+      "title": "Why join our testnets?",
+      "reasons": {
+        "tokens": {
+          "title": "Tokens",
+          "text": "Earn tokens distributed on mainnet, launching 2021"
+        },
+        "cash": {
+          "title": "Cash",
+          "text": "Get rewarded with real money for your participation"
+        },
+        "reputationAndSkill": {
+          "title": "Reputation & Skill",
+          "text": "Gain the knowledge required to participate on mainnet"
+        }
+      }
+    },
+    "exploreJoystream": {
+      "title": "Explore Joystream Now",
+      "subtitle": "Two fast evolving apps for consuming content and governance activities.",
+      "atlas": {
+        "text": "Atlas is the flagship content consumer and publishing app for Joystream. Watch videos, follow creators and discover new featured content, or create a channel and build your audience.",
+        "link": "Try out Atlas",
+        "imageAlt": "overview visual of Atlas"
+      },
+      "pioneer": {
+        "text": "Pioneer is the place to participate in community governance and operation. Vote on elections, submit proposals to fund your project or get enter a paid role to power the platform.",
+        "link": "Try out Pioneer",
+        "imageAlt": "overview visual of Pioneer"
+      }
+    },
+    "roadToMainnet": {
+      "title": "Road to mainnet",
+      "testnetState": {
+        "Current": "Current testnet",
+        "Past": "Past testnet",
+        "Future": "Future testnet"
+      },
+      "released": {
+        "Current": "Released on ",
+        "Past": "Released on ",
+        "Future": "Will be live on "
+      },
+      "testnets": {
+        "Sparta": {
+          "title": "Sparta testnet",
+          "text": "Sparta is our second testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Sparta"
+        },
+        "Athens": {
+          "title": "Athens testnet",
+          "text": "Athens is our third testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Athens"
+        },
+        "Acropolis": {
+          "title": "Acropolis testnet",
+          "text": "Acropolis is our fourth testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Acropolis"
+        },
+        "Rome": {
+          "title": "Rome testnet",
+          "text": "Rome is our second fifth, introducing a variety of important technical improvements.",
+          "explore": "Explore Rome"
+        },
+        "Constantinople": {
+          "title": "Constantinople testnet",
+          "text": "Constantinople is our sixth testnet, introducing a variety of important technical improvements.",
+          "explore": "Explore Constantinople"
+        },
+        "Alexandria": {
+          "title": "Alexandria testnet",
+          "text": "Alexandria is our second seventh, introducing a variety of important technical improvements.",
+          "explore": "Explore Alexandria"
+        },
+        "Babylon": {
+          "title": "Babylon testnet",
+          "text": "Babylon is our second eighth, introducing a variety of important technical improvements.",
+          "explore": "Explore Babylon"
+        },
+        "Antioch": {
+          "title": "Antioch testnet",
+          "text": "Antioch is our ninth testnet, patching a chain split bug which broke the Babylon network",
+          "explore": "Explore Antioch"
+        },
+        "Sumer": {
+          "title": "Sumer testnet",
+          "text": "Sumer is our tenth testnet, facilitating easy content uploads via our playback app.",
+          "explore": "Explore Sumer"
+        }
+      }
+    },
+    "earnTokens": {
+      "title": "Earn mainnet tokens, cash and influence."
+    }
+  }
+}

--- a/src/locales/zh/manifesto.json
+++ b/src/locales/zh/manifesto.json
@@ -1,0 +1,72 @@
+{
+  "manifesto": {
+    "siteMetadata": {
+      "description": "Read the Joystream Manifesto"
+    },
+    "hero": {
+      "title": "The Joystream Manifesto",
+      "text": "Our Manifesto sets out both the problems we believe are associated with digital media platforms in their current form as well as our proposed solution to these concerns."
+    },
+    "problem": {
+      "title": "Problem",
+      "text": {
+        "artAsTool": "We believe that art, be it as literature, music, film, games or performance, is a critical tool through which societies establish a shared understanding of what is common knowledge among all members. These expressions define values and narratives that end up shaping culture, faith and even public policy. It therefore matters deeply how it is financed, distributed and paid for.",
+        "mediaAsPrimaryMedium": "Digital media has become the primary medium through which such expression is distributed, and digital media platforms have become the key institutions organizing this activity.",
+        "unaccountableInstitutions": "Unfortunately, due to network effects, economies of scale, regulations and political interests, we are today left with handful of massive institutions which set the terms for how this happens. They are almost entirely unaccountable to normal market and political mechanisms.",
+        "filteredOnTheirTerms": "As a result, our stories, expressions and interactions are managed and filtered on their terms. This continues to generate an ever changing set of problems, be it",
+        "inflexible": "inflexible monetization, censorship of controversial speech, inequitable sharing of gains with creators and audience, low platform innovation or lack of credibility with third party developers."
+      }
+    },
+    "goal": {
+      "title": "Goal",
+      "text": {
+        "arrangement": "We call for an arrangement where media platforms are accountable to the people they impact, which are primarily their users, be it as consumers, creatives, third party developer or workers.",
+        "accountability": "It is the absence of such accountability which is the fundamental source of any particular problem at any particular time."
+      }
+    },
+    "thesis": {
+      "title": "Thesis",
+      "text": {
+        "coreThesis": "Our core thesis is that there are two basic challenges which must be addressed to achieve this goal, and that an appropriate application of contemporary distributed systems technology, including blockchains, smart contracts and tokens, is the right means to do so."
+      }
+    },
+    "wedge": {
+      "title": "The Wedge",
+      "text": {
+        "alternative": "First is the question of how to create an alternative from scratch in the face of platform externalities which make any new platform nearly useless, regardless of any of its inherent characteristics. The process of doing this sort of bootstrapping has historically been mostly an art, where success has rarely been reproducible.",
+        "blockchainTokens": "We believe that blockchain tokens, earned by and issued to early participants, have been shown to be extremely effective at mobilizing, integrating and motivating an international and dynamic community.",
+        "initialHurdle": "This has now repeatedly allowed nascent communities, like the Bitcoin community, to overcome the initial network effect hurdle [1, 2, 3]. There is no certainty that this will be sufficient, but we believe this mechanism is as promising as anything which is likely to have a chance in a long time."
+      }
+    },
+    "accountability": {
+      "title": "Accountability at scale",
+      "text": {
+        "createAndSustain": "Second is the question of how to create and sustain accountability in such a platform when it actually reaches scale.",
+        "twoWays": "We understand there to be two fundamental ways that participants can hold institutions of any kind accountable: Voice and exit, in the tradition of Hirschman A. O. [4]."
+      }
+    },
+    "voice": {
+      "title": "Voice",
+      "text": {
+        "improveWithin": "Voice is the approach of attempting to improve or reform the functioning of an institution from within. The effectiveness of this depends on some capacity to both share reliable information with other members, and have some impact on internal governance processes. Current media platforms provide users no effective way of doing either.",
+        "infrastructure": "We believe that blockchains provide an organizational and economic infrastructure which can address both problems. The public, verifiable and immutable history of economic and administrative records, provides an excellent basis for users to understand the current and past state of the platform. This allows anyone to make incontestable claims about relevant facts and circumstances.",
+        "control": "Further, blockchain tokens allow us to make use and control of a platform inseparable, giving users an automatic seat at the table in deliberating over platform level decisions.",
+        "signWithCrypto": "All that is required to establish, exercise or transfer the capacity to participate in such activity, is the ability to sign messages with identifiable cryptographic keys. Perfectly reliable contracting gives a large, dynamic and unrestricted set of users the means of governing the platform. This can serve a wide range of purposes, such as undertaking projects, regulating participation in different formally specified roles, or even updating the institutional rules themselves. This integration of reliable contracting into the economic rails provides an organizational infrastructure much more in line with our objectives of inclusive control than the normal jurisdictional trust based infrastructure."
+      }
+    },
+    "exit": {
+      "title": "Exit",
+      "text": {
+        "exit": "Exit is the approach of entirely ending participation in an institution in favor of either joining or creating an alternative. The effectiveness of this depends on costs of leaving, and either joining or creating an alternative, all being low compared to the deprivation in the existing institution. This is currently not the case.",
+        "loweredCosts": "By building platforms based on free & open source software, open protocols and open data — as is the case with Blockchain systems, one dramatically lowers these costs. Since users control their own data, identity and assets, they have a much easier time joining new platforms, and even taking their peers with them.",
+        "competition": "Open protocols and data will make multi homing interfaces abundant, where users may not even need to switch, but instead use multiple platforms simultaneously, which encourages platform level competition [5].",
+        "reusability": "Even more dramatically, reliance on open source means that all the software capital of a platform can easily be reused, and since the entire organizational state is also public, entire ecosystems can be forked to create new alternative platforms with modified policies and objectives."
+      }
+    },
+    "ctaText": "This plan still has room for more people, so get involved by sending an <0>email</0> or joining us on <1>Discord</1> or <2>Reddit</2>.",
+    "references": {
+      "title": "References",
+      "text": "<0>[1] Ersam, F. Blockchain Tokens and the dawn of the Decentralized Business Model. Medium. Aug 1, 2016.</0><0>[2] Srinivasan, B. S. Thoughts on Tokens. Medium. May 27, 2017.</0><0>[3] Dixon, C. Crypto Tokens: A Breakthrough in Open Network Design. Medium. June 1, 2017.</0><0>[4] Hirschman, Albert O. Exit, voice, and loyalty: Responses to decline in firms, organizations, and states. Vol. 25. Harvard university press, 1970.</0><0>[5] Rochet, Jean‐Charles, and Jean Tirole. “Platform competition in two‐sided markets.” Journal of the european economic association 1.4 (2003): 990–1029.</0>"
+    }
+  }
+}

--- a/src/locales/zh/privacy-policy.json
+++ b/src/locales/zh/privacy-policy.json
@@ -1,0 +1,59 @@
+{
+  "privacyPolicy": {
+    "siteMetadata": {
+      "description": "Joystream Privacy and Cookie Policy"
+    },
+    "hero": {
+      "title": "Privacy Policy and Cookies",
+      "text": "<0><0>Jsgenesis values your privacy.</0><1/><1/>This Privacy Policy (\"Privacy Policy\") and Cookie Policy (\"Cookie Policy\") explains how Jsgenesis AS (\"Jsgenesis\", \"Company\", \"We\", \"Us\", \"Our\") collect and use data and information when you (\"User) use on or any of the Joystream products, developed in the GitHub organization <3>Joystream</3>. These products (collectively \"Software\") include, but are not limited to, all pages under the <6>joystream.org</6> domain (\"Website\"), the <10>Joyful node</10> (\"Full Node\"), the <14>Colossus Storage Node</14> (\"Storage node\"), and the Pioneer User Interface, either <18>self hosted</18> or <22>hosted by Us</22>  (\"App\").</0>"
+    },
+    "terms": {
+      "title": "Relevant to the Privacy Policy and Cookie Policy are the following terms:",
+      "blockchain": "The term <0>\"Blockchain\"</0> refers to the blockchain(s) assembled by the Full Node.",
+      "content": "The term <0>\"Content\"</0> refers to media files accessible through our Software.",
+      "keys": "The term <0>\"Keys\"</0> refers to a private/public cryptographic keypair, that Users can generate in order to write (and decrypt data) on the Blockchain.",
+      "membership": "The term <0>\"Membership\"</0> refers to tying your Keys to a public profile, allowing users to access Content and interact with the Blockchain.",
+      "memo": "The term <0>\"Memo\"</0> refers to a markdown enabled text field, where users can input data tied to their Keys."
+    },
+    "privacyPolicyItems": {
+      "title": "Privacy Policy",
+      "subtitle": "Last updated on the 17th of April 2019",
+      "agreement": {
+        "title": "1. Agreement to the Policy",
+        "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
+      },
+      "changes": {
+        "title": "2. Changes to Policy",
+        "content": "This Privacy Policy may be changed at the sole discretion of Company. If any material changes are made, the User will be notified in the Service that is used. Note that adding new products to be included in the term Software, e.g. a new User facing product replacing the App or a new tool for uploading Content, is not considered material as it will not affect Users unless they adopt the new product. Changing software names, terminology used in this Privacy Policy, and changing link locations are also examples of non-material changes."
+      },
+      "informationCollected": {
+        "title": "3. Information Collected",
+        "content": "All data written to the Blockchain, is implicitly collected not only by Company, but also anyone else in the world that is running the Full Node locally, or accessed via the App or a third party. This includes, but is not limited to, Content hashes, Membership profile, Memo field, and any other way a User can record data on the Blockchain. ‍<0/><0/> When using the <1>faucet</1> subpage of the Website, Company will record the IP address behind every new request for tokens. This data will be deleted every 14 days."
+      },
+      "googleAnalytics": {
+        "title": "",
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+      }
+    },
+    "cookiePolicyItems": {
+      "title": "Cookies Policy",
+      "subtitle": "Last updated on the 17th of April 2019",
+      "whatAreCookies": {
+        "title": "1. What are Cookies?",
+        "content": "Cookies are small pieces of text sent by your web browser by a website you visit. A cookie file is stored in your web browser and allows the Service or a third-party to recognise you and make your next visit easier and the Service more useful to you. ‍<0 />‍<0 /> Cookies can be persistent or session cookies."
+      },
+      "howWeUseCookies": {
+        "title": "2. How we use Cookies",
+        "content": "We use cookies for the following purposes our Service: <0 /><0 /><1><0>Provide Analytics</0><0>Store preferences</0><0>Persistant local storage of Keys and Membership.</0></1>"
+      },
+      "thirdPartyCookies": {
+        "title": "3. Third-party Cookies",
+        "content": "In addition to our own cookies, we also use various third-party cookies to report usage statistics of the Service, deliver advertisements on and through the Service, and so on. They include:<0/><0/><1><0><0>Google Analytics</0></0><0><0>Mailchimp</0> (Only when signing up for any of our newsletters)</0><0><0>Godaddy</0></0></1><0 />Please see Item 3. of the Privacy Policy for more information on the extent of these providers."
+      },
+      "regardingYourCookies": {
+        "title": "Regarding Your Cookies",
+        "content": "If you would like to delete cookies or instruct your web browser to delete or refuse cookies, please visit the help pages of your web browser.<0 />‍<0 /> Please note, however, that if you delete cookies or refuse to accept them, you might not be able to use all of the features we offer, you may not be able to store your preferences, and some of our pages might not display properly."
+      }
+    }
+  }
+}

--- a/src/locales/zh/roles.json
+++ b/src/locales/zh/roles.json
@@ -1,0 +1,197 @@
+{
+  "roles": {
+    "siteMetadata": {
+      "description": "Read more about current and future roles on the Joystream platform"
+    },
+    "hero": {
+      "title": "Choose your preferred role",
+      "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."
+    },
+    "validator": {
+      "title": "Validator",
+      "overview": "The Joystream platform state lives on a blockchain consensus system. This consensus system is a variant of classical BFT consensus combined with Proof-of-Stake to determine voting power. A validator is an actor which checks the validity of newly constructed blocks, proposes new blocks and participates in the consensus process for committing new block to the chain. This role has a purpose very similar to the miners in the Bitcoin blockchain. Importantly, anyone can fully check the validity of the blockchain, not just validators, and this is called validation.",
+      "responsibilities": {
+        "runAndMaintainScreeningNodes": "Run and maintain screening nodes that are always available and performant",
+        "enforceRules": "Help enforce the consensus rules of the network"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage, (up & down) bandwidth and processing capacity",
+        "storeKeys": "Able to securely store keys",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "councilMember": {
+      "title": "Council Member",
+      "overview": "At the heart of the governance process on the platform is the proposal system, which allows anyone to submit some suggestion for changing the state or policy of the platform in some way. These proposals are processed and voted on by a council, where the participants are referred to as council members. A seat on the council is won through an election process, and lasts for some period of time until a new election.",
+      "responsibilities": {
+        "discussProposals": "Discuss the meaning and merits of incoming proposals, covering a broad range of topics",
+        "vote": "Vote on proposals",
+        "representCommunity": "Represent the community members and your constituency to make day-to-day operations decisions"
+      },
+      "requirements": {
+        "dataAnalysisProficiency": "Proficiency with basic data analysis and sufficient reputation and standing within the community to earn supporting votes in elections from other platform members",
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure, function and resource allocation",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "storageProvider": {
+      "title": "Storage Provider",
+      "overview": "There are critical platform assets that do not live on the blockchain, such as images and content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enables uploading and downloading of such data. The storage provider is involved this activity, specifically by storing large quantities of data.",
+      "responsibilities": {
+        "runAndMaintainStorageNodes": "Run and maintain storage nodes that store very large quantities of static data, synchronize with other storage nodes, share data with distributors, and accepts inbound uploads from end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure with high storage capacity",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "storageLead": {
+      "title": "Storage Lead",
+      "overview": "The Storage Lead is hired directly by the Council through the proposals system and is dedicated to the hiring, firing and wider management of Storage Providers on the network.",
+      "responsibilities": {
+        "storageProviderPerformance": "The Storage Lead is responsible for ensuring that Storage Providers are performing adequately. Each one must hold a complete and up-to-date copy of the content directory and ensure uptime in order to effectively serve content consumers."
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "managementAndCoordination": "Ability to effectively manage and coordinate the actions of the Storage Providers",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentCurator": {
+      "title": "Content Curator",
+      "overview": "All of the media content published on the platform lives in an on-chain content directory. There are a range of different content types, and each type has a schema for a rich description of its structure, function and policies. For the effective use of of content, for example in rendering, discovery and monetization, it is critical to ensure the validity of the published information for all content. In particular, it is also important to resolve possible disputes about ownership and presence of any piece of content on the platform. It is the task of the content curators to do the work involved in processes that address these objectives.",
+      "responsibilities": {
+        "monitorContent": "Monitor the publishing of new content into the content directory, and respond to reports about contested publications",
+        "adjudicateDisputes": "Adjudicate possible dispute processes resulting from reports from users",
+        "updateContentInformation": "Update information on content to be accurate",
+        "collaborateWithBuilders": "Collaborate with <0> Builders</0> to improve both tools, and user facing experiences, to improve the integrity of the content directory"
+      },
+      "requirements": {
+        "adjudicateDisputes": "Fairly adjudicate disputes, and communicate in clear and transparent way with stakeholders and participants",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentCreator": {
+      "title": "Content Creator",
+      "overview": "As a video platform, one of the most important platform assets is the content published on the platform. Since video is such a flexible media type, which can encompass a wide range of content categories, it is the primary focus. However, the intention is to support a broader range of content types over time. The content creators are those involved in creating, publishing and monetizing content on the platform.",
+      "responsibilities": {
+        "publishContent": "Publish content and build an audience"
+      },
+      "requirements": {
+        "publishContent": "Have the right to publish existing or new content to the platform",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "contentLead": {
+      "title": "Content Lead",
+      "overview": "The Council has the power to appoint a Content Curator Lead for the network who can hire further Content Curators. The Content Lead also decides on priorities for curation. If necessary, upon discussing with the council, the Lead can also decide to fire curators who are not performing their jobs adequately.",
+      "responsibilities": {
+        "monitorPublishing": "Monitor the publishing of new content into the content directory, and respond to reports about contested publications",
+        "adjudicateDisputes": "Adjudicate possible dispute processes resulting from reports from users",
+        "updateInformation": "Update information on content to be accurate",
+        "manageAndCoordinate": "Manage and coordinate the actions of the Content Working Group"
+      },
+      "requirements": {
+        "adjudicateDisputes": "Fairly adjudicate disputes, and communicate in clear and transparent way with stakeholders and participants",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "membershipScreener": {
+      "title": "Membership Screener",
+      "overview": "A membership is an integrated representation of identifying information and associated activities of an actor on the platform. The direct way of establishing membership will be to simply pay a one time fee. However, since its currently challenging for many prospective non-technical end users to obtain, store and use crypto assets, there will be a way for users to get a membership for free, which will not require any tokens in order to use the platform in a limited capacity. The membership screener is the role responsible for granting such memberships, while screening for Sybill attackers and abusers.",
+      "responsibilities": {
+        "runAndMaintainScreeningNodes": "Run and maintain screening nodes that are always available and performant",
+        "collaborate": "Collaborate with <0>Membership Curators</0> and <1>Builders</1> to improve screening mechanisms by discussing screening techniques, sharing traffic information",
+        "beResponsive": "Be responsive and reactive to changing circumstances"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage, (up & down) bandwidth and processing capacity",
+        "onlinePlatformAttackFamiliarity": "Familiarity with how online platforms are attacked through botnets, IP anonymization, automated agents, etc.",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "membershipCurator": {
+      "title": "Membership Curator",
+      "overview": "A membership is an integrated representation of identifying information and associated activities of an actor on the platform. It is possible to create memberships for free through the screeners, described <0> above</0>. Since this is invariably an imperfect process, there must be some means by which bad conduct and fake accounts can be disabled or removed. This is the task of the membership curators.",
+      "responsibilities": {
+        "monitorPlatformActivity": "Monitor platform level activity for abuse and collusion",
+        "proposeChanges": "Propose changes to status of memberships which are identified, and participate in any dispute process which may follow",
+        "collaborate": "Collaborate with <0> Screeners</0> and <1> Builders</1> to improve tools for identifying such members"
+      },
+      "requirements": {
+        "dataAnalysisProficiency": "Proficient with basic data analysis and scripting",
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure, function and attack vectors",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "bandwidthProvider": {
+      "title": "Bandwidth Provider",
+      "overview": "There are critical platform assets that do not live on the blockchain, such as images and content media. The integrity of these assets is secured by the chain, but a separate set of storage and distribution nodes enable uploading and downloading of such data. The bandwidth provider is involved this activity, specifically by distributing static data to end users at scale.",
+      "responsibilities": {
+        "runAndMaintainDistributorNodes": "Run and maintain distributor nodes that deliver large volumes of upstream data to a large number of simultaneous end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with high storage capacity and a lot of upstream capacity",
+        "locatedWithinBounds": "Located within certain bounds to designated geographic areas, in order to limit latency",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "discoveryProvider": {
+      "title": "Discovery Provider",
+      "overview": "All of the content on the platform is in a designated content directory, and effectively navigating this directory requires a full copy of this directory. Moreover, in order to do things like search and context based recommendations one needs to apply some sort of heuristic on top of this directory, which is also some what sensitive abusive attempts to rank higher. The discovery providers play the role of responding to such discovery queries to end users, by combining light client inclusion proofs with local search and ranking policy heuristics.",
+      "responsibilities": {
+        "runAndMaintainDiscoveryNodes": "Run and maintain discovery nodes that respond to discovery-related queries by staying in sync with the content directory, and applying local ranking heuristics.",
+        "collaborate": "Collaborate with <0>Builders</0> to improve both tools, and user facing experiences, to improve the discovery experience"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure",
+        "formulateAndTestHeuristics": "Able to formulate, test and suggest new ranking heuristics for use by discovery provider nodes",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "liveStreamingProvider": {
+      "title": "Live Streaming Provider",
+      "overview": "The platform supports live video, allowing publisher to distribute content as it is created. The live streaming providers are responsible for directly, or indirectly from peer providers, taking a (transcoded) stream from the source publisher, and relaying it to end users.",
+      "responsibilities": {
+        "runAndMaintainLivestreamingNodes": "Run and maintain live streaming nodes that deliver large volumes of upstream data to a large number of simultaneous end users"
+      },
+      "requirements": {
+        "setupAndMaintainInfrastructure": "Experienced with how to setup and maintain high performance IT infrastructure",
+        "accessToPerformantInfrastructure": "Access to highly performant and reliable IT infrastructure, with large amount of upstream bandwidth capacity.",
+        "locatedWithinBounds": "Located within certain bounds to designated geographic areas, in order to limit latency",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "builder": {
+      "title": "Builder",
+      "overview": "The platform runtime, tools, infrastructure software and user facing applications are all meant to evolve over time. A diverse set of contributors are required to facilitate this, including <0/><0/> <1> <0><0>Developers:</0> Software developers, Data scientists, DevOps and QA </0><0><0>Designers:</0> Web, Mobile, UX/UI, Branding and Visual Design </0> <0><0>Product Managers:</0> Digital Product Managers, Product Owners and Analysts </0> </0> <0 /> All of these contributors are collectively referred to as Builders. Anyone can contribute in the same mode as any of these possible contributor functions, as all the platform source assets are open source and developed in the open. Being a Builder means that one has some scope of responsibility in ongoing efforts, and that one has some predefined reward scheme associated with this responsibility.",
+      "responsibilities": {
+        "collaborate": "Collaborate with almost every other kind of platform member to maintain and improve the platform"
+      },
+      "requirements": {
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure and function",
+        "specificContributingSkills": "Have specific skills required for contributing in the given way",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    },
+    "communicationModerator": {
+      "title": "Communication Moderator",
+      "overview": "The platform will have multiple ways of facilitating easy and secure public, and private, communication and information sharing among members. In particular, there will be both a forum and messaging capability built in to the platform. But in order for these spaces to be effective communication modes, some moderation will be required. Communication moderators are involved with policing this activity.",
+      "responsibilities": {
+        "monitorCommuncationChannels": "Monitor and supervise public communication channels for compliance with usage policies as decided through the governance system",
+        "communicateWithUsers": "Communicate with end users about any possible violations and sanctions",
+        "collaborate": "Collaborate to come up with new policies as circumstances change"
+      },
+      "requirements": {
+        "platformUnderstanding": "A deep understanding of the Joystream platform structure and function",
+        "goodCommunicator": "Clear written communicator, ideally with good command of more than one language",
+        "stake": "Hold sufficient amount of the native platform token to put at stake"
+      }
+    }
+  }
+}

--- a/src/locales/zh/rome.json
+++ b/src/locales/zh/rome.json
@@ -1,0 +1,59 @@
+{
+  "rome": {
+    "siteMetadata": {
+      "description": "Explore the Rome testnet"
+    },
+    "hero": {
+      "title": "Rome Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "REPLACED BY CONSTANTINOPLE ON"
+    },
+    "modal": {
+      "title": "Rome",
+      "text": "<0>The Roman empire left many landmarks.</0> Their architecture and engineering skills was unparalleled during their might. The concept of aqueducts was not devised by the Romans, but their beauty and extent is."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "fullSpecifications": {
+        "title": "Full Specifications",
+        "text": "No specifications were published for Rome."
+      },
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our Release <0>OKR</0>",
+      "goals": {
+        "contentDirectory": {
+          "title": "Build a dynamic, flexible and user friendly content directory",
+          "text": "The Rome testnet is built around the introduction of a new content directory, that can be added to, modified and improved without requiring runtime upgrades. All key results and goals are derived from this."
+        },
+        "content": {
+          "title": "Populate the content directory with a variety of content",
+          "text": "Rome introduces a Content Directory system that is both built to last, yet still meant to be continuously improved on. We will pay for Content Creators to upload a variety of content and we hope to learn a lot from the results."
+        },
+        "contentCurator": {
+          "title": "Introduce the new Content Curator role",
+          "text": "With a new Content Directory, and incentives to upload content, we need monitoring. The Content Curators will require staking, and will be paid in both testnet tokens and Monero."
+        },
+        "contentCreator": {
+          "title": "Add Content Creator profiles",
+          "text": "Without Content Creators, there won't be any content. Granted, adding another level on top of the membership requirement may seem like a hurdle, but it will allow users to upload with multiple profiles."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Rome Network"
+    },
+    "map": {
+      "title": "Rome",
+      "text": "<0>Rome was the capital of the great Roman Empire during its peak.</0> As with previous testnet names, the Roman Empire and Rome was another important step in the rise of democracy, the rule of law, and modern governance structures.<1/><1/><2><0/> Explore current testnet</2>"
+    }
+  }
+}

--- a/src/locales/zh/sparta.json
+++ b/src/locales/zh/sparta.json
@@ -1,0 +1,41 @@
+{
+  "sparta": {
+    "siteMetadata": {
+      "description": "Explore the Sparta testnet"
+    },
+    "hero": {
+      "title": "Sparta Network",
+      "text": "Explore available roles and pick the one that suits you best. Influence the platform's development and earn real money in the process.",
+      "chipText": "What is this?"
+    },
+    "heroCard": {
+      "title": "NETWORK DOWN",
+      "markdown": "\n ### FAILURE IDENTIFIED\n\n  On Friday the 29th of March, the Sparta network went down due to a [known bug in substrate](https://github.com/paritytech/substrate/pull/2130) that we had not pulled down before release.\n\n  More details can be found in this [blog post](https://blog.joystream.org/sparta-sacked/)."
+    },
+    "modal": {
+      "title": "Helmet of Sparta",
+      "text": "<0>The Spartan army helmet</0> represents what Sparta is most known for today, their military might. For it's time, it was also known for its advanced governance system."
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals below are a simplified representation of the Key Results listed in our release OKR.",
+      "goals": {
+        "blockchain": {
+          "title": "Build and release a blockchain with a working Council",
+          "text": "As a \"user governed media platform\", allowing users to elect <0>Council Members</0> to represent their interest in day-to-day operations was a major goal for us."
+        },
+        "bugs": {
+          "title": "Keep the quantity of more or less critical bugs at an acceptable level",
+          "text": "As demonstrated by the fact that the network crashed, we did not reach our goals in this case."
+        }
+      }
+    },
+    "roles": {
+      "title": "Roles available on the Sparta testnet"
+    },
+    "map": {
+      "title": "The city of Sparta",
+      "text": "<0>Sparta was a prominent city-state in Ancient Greece.</0> In addition to its military might, it was also unique both for its time and compared to its greek rivals due its defined social system and constitution. <1/><1/> We chose the name Sparta due to it's historical significance in the path towards democracy and rule of law, however draconian by modern standard."
+    }
+  }
+}

--- a/src/locales/zh/sumer.json
+++ b/src/locales/zh/sumer.json
@@ -1,0 +1,47 @@
+{
+  "sumer": {
+    "siteMetadata": {
+      "description": "Explore the Sumer testnet"
+    },
+    "hero": {
+      "title": "Sumer Network",
+      "text": "Among other changes, the Sumer testnet release offers major improvements to content uploads through our playback app."
+    },
+    "criticalDocuments": {
+      "title": "Critical Documents",
+      "releasePlan": {
+        "title": "Release Plan",
+        "text": "Read the release plan as it was made during the planning stage, and learn more about how the development evolved."
+      },
+      "blogPost": {
+        "title": "Announcement Blog Post",
+        "text": "Read a brief primer on the Sumer testnet and its objectives."
+      }
+    },
+    "testnetGoals": {
+      "title": "Testnet Goals",
+      "subtitle": "The goals listed below are a simplified representation of our main objectives for the Sumer testnet.",
+      "goals": {
+        "contentPublishing": {
+          "title": "Enable content publishing from playback interface",
+          "text": "Sumer introduces the ability to create and manage channels and videos in the Joystream Player, replacing the cumbersome and technically challenging CLI-dependent process required on the Antioch testnet."
+        },
+        "deployingNewContentDirectory": {
+          "title": "Deploying the new content directory",
+          "text": "As part of Sumer we will be introducing a simple native runtime module. This is because technical complexities and tradeoffs associated with the previous iterations of the content directory were not acceptable."
+        },
+        "enableBuilderRole": {
+          "title": "Enable builder/platform operations role",
+          "text": "We are introducing a new working group focused on platform operations. Originally, we had also planned to enable the new \"Gateway\" role, though this is no longer in the scope of the Sumer release."
+        }
+      }
+    },
+    "roles": {
+      "title": "Incentivized Roles for the Sumer Network"
+    },
+    "map": {
+      "title": "Sumer",
+      "text": "<0>Sumer is the earliest known civilization in the historical region of southern Mesopotamia</0>, emerging during the Chalcolithic and early Bronze Ages between the sixth and fifth millennium BC.<1/><1/>Living along the valleys of the Tigris and Euphrates, Sumerian farmers grew an abundance of grain and other crops, the surplus from which enabled them to form urban settlements. The region is thought to be where the earliest forms of writing emerged.<1/><1/><2><0/> Read the blog post</2>"
+    }
+  }
+}

--- a/src/locales/zh/token.json
+++ b/src/locales/zh/token.json
@@ -1,0 +1,67 @@
+{
+  "token": {
+    "siteMetadata": {
+      "title": "Token",
+      "description": "Participants on our testnets can now earn Joystream Testnet Tokens (tJOYs) backed by fiat currency."
+    },
+    "hero": {
+      "title": "Understanding the tJOY token",
+      "text": "Participants on our testnets can now earn Joystream Testnet Tokens (tJOYs) backed by fiat currency.",
+      "tokenStats": {
+        "title": "Token in numbers",
+        "exchangeRate": "Exchange Rate",
+        "backingValue": "Backing Value",
+        "supply": "Supply"
+      }
+    },
+    "faq": {
+      "title": "Testnet Token Information",
+      "whatIsTJoy": {
+        "title": "What is tJOY?",
+        "text": "tJOY (testJOY) is the currency used on Joystream incentivized testnets."
+      },
+      "tJoyValueOrigin": {
+        "title": "Where does the value of tJOY come from?",
+        "text": "Jsgenesis, the team behind the Joystream project, have linked the total supply of tJOYs to a corresponding pool of fiat currency (USD) held by the company. All testnet participants can redeem their tJOY for USD at any time."
+      },
+      "purposeOfTJoy": {
+        "title": "What is the purpose of tJOY?",
+        "text": "tJOY can be used on our testnets in the same ways that future users of the Joystream platform will be able to use the mainnet JOY token. The three principal functions of tJOY are in staking, governance and for payment.<0/><0/> For example, to participate in testnet roles, users may need to stake tJOY. To create governance proposals and vote for Council Members, tJOY is also required. Finally, on the testnet, bounties and KPIs require tJOYs for paying effective contributors."
+      },
+      "whereCanTJoyBeObtained": {
+        "title": "Where can I get tJOY?",
+        "text": "There are many opportunities to obtain tJOY. Smaller amounts can be requested in our community channels (including our Discord server and on-chain forum), while larger sums can be accumulated by participating in bounties, competitions and other events."
+      },
+      "linkBetweenTJoyAndFutureToken": {
+        "title": "Is there any link between tJOY and the future mainnet token?",
+        "text": "There is no direct link between tJOY and mainnet JOY. We are using tJOY to simulate the real economic incentives present on mainnet to aid the platform's development and facilitate the growth and education of our community in preparation of the transition from testnet to mainnet."
+      },
+      "howToCashout": {
+        "title": "How do I cashout tJOY to USD?",
+        "text": "We use Bitcoin Cash (BCH) as a payment rail on our testnets. You can cashout tJOY by making a transfer to the dedicated burn address: <0>5D5PhZQNJzcJXVBxwJxZcsutjKPqUPydrvpu6HeiBfMaeKQu</0> Before doing this, you should set the <0>memo</0> of the key from which the transfer is made to your BCH address. At the moment of the transfer, the BCH to USD exchange rate is locked. <1/><1/>More information on payouts can be found <2>here</2>."
+      },
+      "howToEarn": {
+        "title": "How can I earn mainnet JOY?",
+        "text": "Currently, the only way to secure an allocation of mainnet JOY is through high-quality contributions to the platform and community via our <0>Founding Member Program</0>."
+      },
+      "TJoyWorth": {
+        "title": "How much is tJOY worth?",
+        "text": "You can check the live exchange rate (tJOY->USD) on this page (see above)."
+      }
+    },
+    "cashouts": {
+      "title": "Pending cashouts",
+      "subtitle": "Tokens sent to Jsgenesis in this exchange are burned, hence the final price of the token is unaffected by such an exchange.",
+      "cashout": {
+        "address": "Source address",
+        "tokensTransferred": "Tokens transferred",
+        "usdValue": "USD Value",
+        "blockNumber": "Block Number",
+        "exchangeNumber": "Exchange #"
+      }
+    },
+    "cta": {
+      "title": "Join our Discord and change the online video industry"
+    }
+  }
+}


### PR DESCRIPTION
This PR aims to add support for French, Spanish and Mandarin to enable users to add translations as a part of the larger Joystream-org internationalization project. 