### PR TITLE
Update links to assets based on new folder structure

### DIFF
--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -97,14 +97,21 @@ const Navbar = ({ light, links, t }) => {
           <Logo className={cn('Navbar__logo', { 'Navbar__logo--open': isOpen })} />
         </Link>
 
-        <div className={`Navbar__links ${isOpen ? 'Navbar__links--open' : ''}`}>
+        <div
+          className={cn('Navbar__links', {
+            'Navbar__links--open': isOpen,
+            'Navbar__links--light' : light
+          })}
+        >
           {links.map(({ label, isButton, isDropdown, links, href, to }) => {
             if (isDropdown) {
               return <Dropdown key={label} t={t} label={t(label)} links={links} isScrollUp={isScrollUp} />;
             }
 
             let children = (
-              <div className="Navbar__link-wrapper">
+              <div className={cn("Navbar__link-wrapper", {
+                "Navbar__link-wrapper--light" : light
+              })}>
                 <p className="Navbar__link">{t(label)}</p>
               </div>
             );

--- a/src/components/Navbar/style.scss
+++ b/src/components/Navbar/style.scss
@@ -50,6 +50,10 @@
     flex-direction: row;
     width: auto;
     background-color: $c_black;
+
+    &--light {
+      background-color: $c_blue-ribbon;
+    }
   }
 
   &__link-wrapper {
@@ -60,6 +64,10 @@
     color: #a7aeb7;
     cursor: pointer;
     user-select: none;
+
+    &--light {
+      color: white;
+    }
 
     &:hover {
       color: white;

--- a/src/pages/brand/assets/index.js
+++ b/src/pages/brand/assets/index.js
@@ -14,10 +14,10 @@ import convertToCamelCase from '../../../utils/convertToCamelCase';
 import typographyImg from '../../../assets/images/typography-overview.png';
 import './index.scss';
 
-const ASSETS_LINK = 'https://raw.githubusercontent.com/Joystream/design/master/Assets-full';
+const ASSETS_LINK = 'https://raw.githubusercontent.com/Joystream/design/master';
 const FONT_DOWNLOAD_URL = 'https://www.fontsquirrel.com/fonts/download/inter';
 
-const getPackageLink = path => encodeURI(ASSETS_LINK + '/ZIPPED files' + path);
+const getPackageLink = path => encodeURI(ASSETS_LINK + '/zipped-assets' + path);
 
 const themedAssetRenderer = (asset, t) => {
   return (


### PR DESCRIPTION
This PR aims to fix this issue: https://github.com/Joystream/joystream-org/issues/375

Changes:
- Updated links to assets based on new folder structure.
- Fixed light navbar colors (that I've missed when doing the navbar overhaul)