### PR TITLE
Fix bounty card clipping problem

### DIFF
--- a/src/components/get-started/Bounties/Carousel/index.js
+++ b/src/components/get-started/Bounties/Carousel/index.js
@@ -20,7 +20,7 @@ const parseDate = dateString => {
 
 const BountiesCard = ({ title, amount, categories, date, id, link, description }) => {
   return (
-    <a target="_blank" href={link ? link : '#'}>
+    <a className="GetStarted__bounties-carousel__card-wrapper-link" target="_blank" href={link ? link : '#'}>
       <div className="GetStarted__bounties-carousel__card">
         <div className="GetStarted__bounties-carousel__top">
           <p className="GetStarted__bounties-carousel__amount">${amount}</p>
@@ -52,7 +52,7 @@ const BountiesCard = ({ title, amount, categories, date, id, link, description }
   );
 };
 
-const CARD_SIZE_WITH_MARGIN = 424;
+const CARD_SIZE_WITH_MARGIN = 405;
 
 const BountiesCarousel = ({ t }) => {
   const [data, loading, error] = useAxios(bountiesLink);
@@ -65,9 +65,11 @@ const BountiesCarousel = ({ t }) => {
     Marketing: 0,
     Research: 0,
     Content: 0,
-    Translation: 0
+    Translation: 0,
   });
   const [bounties, setBounties] = useState();
+
+  console.log(bounties);
 
   useEffect(() => {
     if (data && !loading) {
@@ -78,7 +80,7 @@ const BountiesCarousel = ({ t }) => {
         Marketing: 0,
         Research: 0,
         Content: 0,
-        Translation: 0
+        Translation: 0,
       };
 
       data.activeBounties.forEach(bounty => {
@@ -161,41 +163,45 @@ const BountiesCarousel = ({ t }) => {
       </div>
       <CardCarousel scrollAmount={CARD_SIZE_WITH_MARGIN}>
         <div className="GetStarted__bounties-carousel">
-          {bounties?.map((bounty, idx) => {
-            if (filterState === 'All') {
-              return (
-                <BountiesCard
-                  key={bounty?.title + idx}
-                  title={bounty?.title}
-                  amount={bounty?.reward}
-                  categories={bounty?.tags}
-                  date={bounty?.openedDate}
-                  id={bounty?.id}
-                  link={bounty?.links[0]}
-                  description={bounty?.description}
-                />
-              );
-            } else {
-              const categories = bounty?.tags;
+          {bounties
+            ? bounties
+                .sort((a, b) => new Date(b.openedDate) - new Date(a.openedDate))
+                .map((bounty, idx) => {
+                  if (filterState === 'All') {
+                    return (
+                      <BountiesCard
+                        key={bounty?.title + idx}
+                        title={bounty?.title}
+                        amount={bounty?.reward}
+                        categories={bounty?.tags}
+                        date={bounty?.openedDate}
+                        id={bounty?.id}
+                        link={bounty?.links[0]}
+                        description={bounty?.description}
+                      />
+                    );
+                  } else {
+                    const categories = bounty?.tags;
 
-              if (categories && categories.includes(filterState)) {
-                return (
-                  <BountiesCard
-                    key={bounty?.title + idx}
-                    title={bounty?.title}
-                    amount={bounty?.reward}
-                    categories={bounty?.tags}
-                    date={bounty?.openedDate}
-                    id={bounty?.id}
-                    link={bounty?.links[0]}
-                    description={bounty?.description}
-                  />
-                );
-              }
+                    if (categories && categories.includes(filterState)) {
+                      return (
+                        <BountiesCard
+                          key={bounty?.title + idx}
+                          title={bounty?.title}
+                          amount={bounty?.reward}
+                          categories={bounty?.tags}
+                          date={bounty?.openedDate}
+                          id={bounty?.id}
+                          link={bounty?.links[0]}
+                          description={bounty?.description}
+                        />
+                      );
+                    }
 
-              return null;
-            }
-          })}
+                    return null;
+                  }
+                })
+            : null}
         </div>
       </CardCarousel>
     </div>

--- a/src/components/get-started/Bounties/Carousel/index.js
+++ b/src/components/get-started/Bounties/Carousel/index.js
@@ -69,8 +69,6 @@ const BountiesCarousel = ({ t }) => {
   });
   const [bounties, setBounties] = useState();
 
-  console.log(bounties);
-
   useEffect(() => {
     if (data && !loading) {
       const tempCategoryValues = {
@@ -164,44 +162,42 @@ const BountiesCarousel = ({ t }) => {
       <CardCarousel scrollAmount={CARD_SIZE_WITH_MARGIN}>
         <div className="GetStarted__bounties-carousel">
           {bounties
-            ? bounties
-                .sort((a, b) => new Date(b.openedDate) - new Date(a.openedDate))
-                .map((bounty, idx) => {
-                  if (filterState === 'All') {
-                    return (
-                      <BountiesCard
-                        key={bounty?.title + idx}
-                        title={bounty?.title}
-                        amount={bounty?.reward}
-                        categories={bounty?.tags}
-                        date={bounty?.openedDate}
-                        id={bounty?.id}
-                        link={bounty?.links[0]}
-                        description={bounty?.description}
-                      />
-                    );
-                  } else {
-                    const categories = bounty?.tags;
+            ?.sort((a, b) => new Date(b.openedDate) - new Date(a.openedDate))
+            .map((bounty, idx) => {
+              if (filterState === 'All') {
+                return (
+                  <BountiesCard
+                    key={bounty?.title + idx}
+                    title={bounty?.title}
+                    amount={bounty?.reward}
+                    categories={bounty?.tags}
+                    date={bounty?.openedDate}
+                    id={bounty?.id}
+                    link={bounty?.links[0]}
+                    description={bounty?.description}
+                  />
+                );
+              } else {
+                const categories = bounty?.tags;
 
-                    if (categories && categories.includes(filterState)) {
-                      return (
-                        <BountiesCard
-                          key={bounty?.title + idx}
-                          title={bounty?.title}
-                          amount={bounty?.reward}
-                          categories={bounty?.tags}
-                          date={bounty?.openedDate}
-                          id={bounty?.id}
-                          link={bounty?.links[0]}
-                          description={bounty?.description}
-                        />
-                      );
-                    }
+                if (categories && categories.includes(filterState)) {
+                  return (
+                    <BountiesCard
+                      key={bounty?.title + idx}
+                      title={bounty?.title}
+                      amount={bounty?.reward}
+                      categories={bounty?.tags}
+                      date={bounty?.openedDate}
+                      id={bounty?.id}
+                      link={bounty?.links[0]}
+                      description={bounty?.description}
+                    />
+                  );
+                }
 
-                    return null;
-                  }
-                })
-            : null}
+                return null;
+              }
+            })}
         </div>
       </CardCarousel>
     </div>

--- a/src/components/get-started/Bounties/Carousel/style.scss
+++ b/src/components/get-started/Bounties/Carousel/style.scss
@@ -12,10 +12,10 @@
     width: 100%;
     margin-top: 40px;
     padding: 0 10px 10px 0;
-    gap: 30px;
+    gap: 25px;
     grid-auto-flow: column;
-    grid-template-columns: 394px;
-    grid-template-rows: 1fr 1fr;
+    grid-template-columns: 380px;
+    grid-template-rows: 1fr 1fr 1fr;
 
     &__filters {
       display: flex;
@@ -79,9 +79,13 @@
       }
     }
 
+    &__card-wrapper-link {
+      width: 380px;
+    }
+
     &__card {
       position: relative;
-      width: 394px;
+      width: 380px;
       height: 200px;
       padding: 15px;
       background-color: white;


### PR DESCRIPTION
This PR aims to fix the problem explained in this issue: https://github.com/Joystream/joystream-org/issues/326

Changes:
- Fix bounty clipping problem by making the bounty cards and grid gaps slightly smaller 
- Add one more row to bounty carousel
- Bounties are now sorted from newest to oldest
- Small link(`a`) tag overflow bugfix

As there aren't enough bounties to visualize the fix, here is a video of how it would look like:

https://user-images.githubusercontent.com/26174828/129700026-dd85b25f-7f07-4298-bc48-156ce4b4c6f0.mp4

