### PR TITLE
Add functionality and translations for missed spots around the website

### DIFF
--- a/__tests__/pages/__snapshots__/athens.test.js.snap
+++ b/__tests__/pages/__snapshots__/athens.test.js.snap
@@ -133,7 +133,7 @@ exports[`AthensPage page renders correctly 1`] = `
           />
         </React.Fragment>
       }
-      title="Testnet Goals"
+      title="athens.testnetGoals.title"
     >
       <GoalList
         data={

--- a/__tests__/pages/__snapshots__/roles.test.js.snap
+++ b/__tests__/pages/__snapshots__/roles.test.js.snap
@@ -410,6 +410,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.validator.responsibilities.enforceRules",
             ]
           }
+          t={[Function]}
           title="roles.validator.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/validators"
           type="active"
@@ -444,6 +445,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.councilMember.responsibilities.representCommunity",
             ]
           }
+          t={[Function]}
           title="roles.councilMember.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/council-members"
           type="active"
@@ -476,6 +478,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.storageProvider.responsibilities.runAndMaintainStorageNodes",
             ]
           }
+          t={[Function]}
           title="roles.storageProvider.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/storage-lead"
           type="active"
@@ -508,6 +511,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.storageLead.responsibilities.storageProviderPerformance",
             ]
           }
+          t={[Function]}
           title="roles.storageLead.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/storage-providers"
           type="active"
@@ -555,6 +559,7 @@ exports[`RolesPage page renders correctly 1`] = `
               />,
             ]
           }
+          t={[Function]}
           title="roles.contentCurator.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/content-curators"
           type="active"
@@ -586,6 +591,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.contentCreator.responsibilities.publishContent",
             ]
           }
+          t={[Function]}
           title="roles.contentCreator.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/content-creators"
           type="active"
@@ -620,6 +626,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.contentLead.responsibilities.manageAndCoordinate",
             ]
           }
+          t={[Function]}
           title="roles.contentLead.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/content-curator-lead"
           type="active"
@@ -668,6 +675,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.builder.responsibilities.collaborate",
             ]
           }
+          t={[Function]}
           title="roles.builder.title"
           tutorialLink="https://github.com/Joystream/helpdesk/tree/master/roles/builders"
           type="active"
@@ -722,6 +730,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.membershipScreener.responsibilities.beResponsive",
             ]
           }
+          t={[Function]}
           title="roles.membershipScreener.title"
           type="upcoming"
         />
@@ -789,6 +798,7 @@ exports[`RolesPage page renders correctly 1`] = `
               />,
             ]
           }
+          t={[Function]}
           title="roles.membershipCurator.title"
           type="upcoming"
         />
@@ -820,6 +830,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.bandwidthProvider.responsibilities.runAndMaintainDistributorNodes",
             ]
           }
+          t={[Function]}
           title="roles.bandwidthProvider.title"
           type="upcoming"
         />
@@ -865,6 +876,7 @@ exports[`RolesPage page renders correctly 1`] = `
               />,
             ]
           }
+          t={[Function]}
           title="roles.discoveryProvider.title"
           type="upcoming"
         />
@@ -896,6 +908,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.liveStreamingProvider.responsibilities.runAndMaintainLivestreamingNodes",
             ]
           }
+          t={[Function]}
           title="roles.liveStreamingProvider.title"
           type="upcoming"
         />
@@ -928,6 +941,7 @@ exports[`RolesPage page renders correctly 1`] = `
               "roles.communicationModerator.responsibilities.collaborate",
             ]
           }
+          t={[Function]}
           title="roles.communicationModerator.title"
           type="upcoming"
         />

--- a/src/components/BrandStory/StorySectionExplanation/index.js
+++ b/src/components/BrandStory/StorySectionExplanation/index.js
@@ -29,7 +29,9 @@ const StorySectionExplanation = React.forwardRef(({ onActionClick, t }, ref) => 
         variant="on-white"
         direction="up"
         onClick={onActionClick}
-      />
+      >
+        {t('brand.guides.general.more')}
+      </ActionButton>
     </BrandLayoutWrapper>
   );
 });

--- a/src/components/BrandStory/StorySectionHeader/index.js
+++ b/src/components/BrandStory/StorySectionHeader/index.js
@@ -28,7 +28,9 @@ const StorySectionHeader = React.forwardRef(({ onActionClick, t }, ref) => {
           <Logo className="StorySectionHeader__image" />
         </div>
       </div>
-      <ActionButton className="StorySectionHeader__action" onClick={onActionClick} />
+      <ActionButton className="StorySectionHeader__action" onClick={onActionClick}>
+        {t('brand.guides.general.more')}
+      </ActionButton>
     </BrandLayoutWrapper>
   );
 });

--- a/src/components/BrandStory/StorySectionLogo/index.js
+++ b/src/components/BrandStory/StorySectionLogo/index.js
@@ -47,7 +47,9 @@ const StorySectionLogo = React.forwardRef(({ onActionClick, t }, ref) => {
         </div>
       </ColumnsLayout>
 
-      <ActionButton className="StorySectionLogo__action" variant="on-blue" onClick={onActionClick} />
+      <ActionButton className="StorySectionLogo__action" variant="on-blue" onClick={onActionClick}>
+        {t('brand.guides.general.more')}
+      </ActionButton>
     </BrandLayoutWrapper>
   );
 });

--- a/src/components/BrandStory/StorySectionWebsite/index.js
+++ b/src/components/BrandStory/StorySectionWebsite/index.js
@@ -29,7 +29,9 @@ const StorySectionWebsite = React.forwardRef(({ onActionClick, t }, ref) => {
         </div>
       </div>
 
-      <ActionButton className="StorySectionWebsite__action" onClick={onActionClick} />
+      <ActionButton className="StorySectionWebsite__action" onClick={onActionClick}>
+        {t('brand.guides.general.more')}
+      </ActionButton>
     </BrandLayoutWrapper>
   );
 });

--- a/src/components/GoalItem/index.js
+++ b/src/components/GoalItem/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { string, oneOf } from 'prop-types';
 import cn from 'classnames';
+import { useTranslation } from 'gatsby-plugin-react-i18next';
+import convertToCamelCase from '../../utils/convertToCamelCase';
 
 import { ReactComponent as AchievedIcon } from '../../assets/svg/achieved.svg';
 import { ReactComponent as InProgressIcon } from '../../assets/svg/in-progress.svg';
@@ -27,13 +29,14 @@ const states = {
 
 const GoalItem = ({ title, className, state, children, ...props }) => {
   const classes = cn('GoalItem', className);
+  const { t } = useTranslation();
 
   const Icon = states[state].icon;
   return (
     <div className={classes} {...props}>
       <div className={`GoalItem__icon-container GoalItem__icon-container--${state}`}>
         <Icon className="GoalItem__icon" />
-        <p className="GoalItem__status">{states[state].name}</p>
+        <p className="GoalItem__status">{t(`testnet.goalStates.${convertToCamelCase(states[state].name)}`)}</p>
       </div>
       <div className="GoalItem__content">
         <p className="GoalItem__title">{title}</p>

--- a/src/components/HydraPage/Video.js
+++ b/src/components/HydraPage/Video.js
@@ -2,12 +2,12 @@ import React from 'react';
 import ReactPlayer from 'react-player';
 import { ReactComponent as PlayIcon } from '../../assets/svg/play.svg';
 
-export default function Video({ src, poster }) {
+export default function Video({ src, poster, subtitle }) {
   return (
     <div className="VideoPlayer Video__Player__Poster">
       <ReactPlayer url={src} light width="100%" height="100%" />
       <div className="VideoPlayer__Release__Text">
-        <span>Release the Hydra</span>
+        <span>{subtitle}</span>
         <PlayIcon />
       </div>
     </div>

--- a/src/components/RoleOverview/index.js
+++ b/src/components/RoleOverview/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { string, oneOfType, node, oneOf, arrayOf, func } from 'prop-types';
 import cn from 'classnames';
 import axios from 'axios';
+import { Trans } from 'gatsby-plugin-react-i18next';
 
 import Link from '../Link';
 import Button from '../Button';
@@ -15,6 +16,7 @@ import { ReactComponent as EnvelopeIcon } from '../../assets/svg/envelop.svg';
 import { ReactComponent as BookIcon } from '../../assets/svg/book.svg';
 
 import './style.scss';
+import convertToCamelCase from '../../utils/convertToCamelCase';
 
 const propTypes = {
   className: string,
@@ -110,15 +112,15 @@ class RoleOverview extends React.Component {
     });
   };
 
-  renderButtons = () => {
+  renderButtons = t => {
     const { tutorialLink, questionLink } = this.props;
     return (
       <div className="RoleOverview__buttons">
         <Button className="RoleOverview__button" href={tutorialLink}>
-          See a tutorial
+          {t('roles.general.seeATutorial')}
         </Button>
         <Button className="RoleOverview__button" href={questionLink} reversed>
-          Ask a question
+          {t('roles.general.askAQuestion')}
         </Button>
       </div>
     );
@@ -130,14 +132,14 @@ class RoleOverview extends React.Component {
     return <FormResponse error={formError} onClose={this.hideForm} />;
   };
 
-  renderFormTitle = (title) => {
+  renderFormTitle = (title, t) => {
     const { type } = this.props;
 
     if (type === 'active') {
       return (
         <>
           <BookIcon className="RoleOverview__form-icon" />
-          Receive regular updates on the {title} role!
+          {t('roles.general.regularUpdates')} {title}
         </>
       );
     }
@@ -145,7 +147,7 @@ class RoleOverview extends React.Component {
     return (
       <>
         <EnvelopeIcon className="RoleOverview__form-icon" />
-        Alert me when the role will be active
+        {t('roles.general.alertWhenActive')}
       </>
     );
   };
@@ -156,12 +158,12 @@ class RoleOverview extends React.Component {
     });
   };
 
-  renderForm = (title, formAction) => {
+  renderForm = (title, formAction, t) => {
     const { formContentVisibility, inputValue, checkboxValue, loading } = this.state;
     const { type } = this.props;
 
     const btnType = type === 'active' ? 'Join' : 'Subscribe';
-    const btnLabel = loading ? 'Please wait...' : btnType;
+    const btnLabel = loading ? 'Please wait' : btnType;
 
     return (
       <>
@@ -171,15 +173,15 @@ class RoleOverview extends React.Component {
           ref={ref => (this.form = ref)}
           action={formAction}
           name="mc-embedded-subscribe-form"
-          target='_blank'
+          target="_blank"
           noValidate
         >
-          <p className="RoleOverview__form-title">{this.renderFormTitle(title)}</p>
+          <p className="RoleOverview__form-title">{this.renderFormTitle(title, t)}</p>
           <Input
-            placeholder="Your email address"
+            placeholder={t('roles.general.emailAddressPlaceholder')}
             type="email"
             className="RoleOverview__form-input"
-            name='EMAIL'
+            name="EMAIL"
             required
             onFocus={this.showFormContent}
             onChange={this.inputChange}
@@ -202,15 +204,17 @@ class RoleOverview extends React.Component {
                 className="RoleOverview__checkbox"
               />
               <label htmlFor="accept" className="RoleOverview__label">
-                <p className="RoleOverview__form-label">I want to receive emails about this role.</p>
+                <p className="RoleOverview__form-label">{t('roles.general.receiveEmailsAboutRole')}</p>
                 <p className="RoleOverview__form-label RoleOverview__form-label--small">
-                  I acknowledge that my information will be transferred to Mailchimp, which has{' '}
-                  <Link href="https://mailchimp.com/legal/">these</Link> privacy practices.
+                  <Trans
+                    i18nKey="roles.general.informationTransferred"
+                    components={[<Link href="https://mailchimp.com/legal/">these</Link>]}
+                  />
                 </p>
               </label>
             </div>
-            <Button type="submit" name='subscribe' disabled={this.state.isButtonDisabled}>
-              {btnLabel}
+            <Button type="submit" name="subscribe" disabled={this.state.isButtonDisabled}>
+              {t(`roles.general.${convertToCamelCase(btnLabel)}`)}
             </Button>
           </div>
         </form>
@@ -230,6 +234,7 @@ class RoleOverview extends React.Component {
       tutorialLink,
       questionLink,
       formAction,
+      t,
       ...props
     } = this.props;
     const { formVisiblity, formResponseVisiblity } = this.state;
@@ -252,12 +257,12 @@ class RoleOverview extends React.Component {
 
         <div className="RoleOverview__content">
           <div className="RoleOverview__overview">
-            <p className="RoleOverview__heading">Overview</p>
+            <p className="RoleOverview__heading">{t('roles.general.overview')}</p>
             <div className="RoleOverview__details">{overview}</div>
           </div>
           <div className="RoleOverview__lists">
             <div className="RoleOverview__list RoleOverview__resposibilities">
-              <p className="RoleOverview__heading--small">Responsibilities</p>
+              <p className="RoleOverview__heading--small">{t('roles.general.responsibilities')}</p>
               <ul className="RoleOverview__details">
                 {responsibilities.map((responsibility, i) => (
                   <li key={i}>{responsibility} </li>
@@ -265,7 +270,7 @@ class RoleOverview extends React.Component {
               </ul>
             </div>
             <div className="RoleOverview__list RoleOverview__requirements">
-              <p className="RoleOverview__heading--small">Requirements</p>
+              <p className="RoleOverview__heading--small">{t('roles.general.requirements')}</p>
               <ul className="RoleOverview__details">
                 {requirements.map((requirement, j) => (
                   <li key={j}>{requirement} </li>
@@ -274,8 +279,8 @@ class RoleOverview extends React.Component {
             </div>
           </div>
 
-          {type === 'active' && this.renderButtons()}
-          {formVisiblity && this.renderForm(title, formAction)}
+          {type === 'active' && this.renderButtons(t)}
+          {formVisiblity && this.renderForm(title, formAction, t)}
           {formResponseVisiblity && this.renderFormResponse()}
         </div>
       </section>

--- a/src/components/get-started/Bounties/Carousel/index.js
+++ b/src/components/get-started/Bounties/Carousel/index.js
@@ -4,6 +4,7 @@ import { ReactComponent as Arrow } from '../../../../assets/svg/arrow-down-small
 import CardCarousel from '../../../../components/CardCarousel';
 import useAxios from '../../../../utils/useAxios';
 import { bountiesLink } from '../../../../data/pages/get-started';
+import convertToCamelCase from '../../../../utils/convertToCamelCase';
 
 import './style.scss';
 
@@ -18,7 +19,7 @@ const parseDate = dateString => {
   return parsedDate;
 };
 
-const BountiesCard = ({ title, amount, categories, date, id, link, description }) => {
+const BountiesCard = ({ title, amount, categories, date, id, link, description, t }) => {
   return (
     <a target="_blank" href={link ? link : '#'}>
       <div className="GetStarted__bounties-carousel__card">
@@ -41,7 +42,7 @@ const BountiesCard = ({ title, amount, categories, date, id, link, description }
                   GetStarted__bounties-carousel__card-filter--${category.toLowerCase()}
                 `}
               >
-                {category}
+                {t(`getStarted.opportunities.bountiesCarousel.${convertToCamelCase(category)}`)}
               </div>
             ))}
           </div>
@@ -64,7 +65,7 @@ const BountiesCarousel = ({ t }) => {
     Design: 0,
     Marketing: 0,
     Research: 0,
-    Content: 0,
+    Content: 0
   });
   const [bounties, setBounties] = useState();
 
@@ -76,7 +77,7 @@ const BountiesCarousel = ({ t }) => {
         Design: 0,
         Marketing: 0,
         Research: 0,
-        Content: 0,
+        Content: 0
       };
 
       data.activeBounties.forEach(bounty => {
@@ -162,6 +163,7 @@ const BountiesCarousel = ({ t }) => {
                   id={bounty?.id}
                   link={bounty?.links[0]}
                   description={bounty?.description}
+                  t={t}
                 />
               );
             } else {
@@ -178,6 +180,7 @@ const BountiesCarousel = ({ t }) => {
                     id={bounty?.id}
                     link={bounty?.links[0]}
                     description={bounty?.description}
+                    t={t}
                   />
                 );
               }

--- a/src/components/index-page/RoadToMainnet/index.js
+++ b/src/components/index-page/RoadToMainnet/index.js
@@ -135,7 +135,7 @@ const RoadToMainnet = ({ t }) => {
   return (
     <div className="IndexPage__road-wrapper">
       <div className="IndexPage__road">
-        <h2 className="IndexPage__road__title">Road to mainnet</h2>
+        <h2 className="IndexPage__road__title">{t("landing.roadToMainnet.title")}</h2>
         <div className="IndexPage__road-main-wrapper">
           <div onClick={() => moveLeft()} role="presentation" className="IndexPage__road-main__arrow-wrapper">
             <Arrow className="IndexPage__road-main__arrow" />

--- a/src/locales/en/general.json
+++ b/src/locales/en/general.json
@@ -131,5 +131,12 @@
   "cookiesNotice": {
     "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
     "findOutMore": "Find out more ›"
+  },
+  "testnet" : {
+    "goalStates": {
+      "achieved" : "achieved",
+      "inProgress" : "in progress",
+      "postponed" : "postponed"
+    }
   }
 }

--- a/src/locales/en/get-started.json
+++ b/src/locales/en/get-started.json
@@ -30,7 +30,10 @@
         "design": "Design",
         "marketing": "Marketing",
         "research": "Research",
-        "contentCreation": "Content Creation"
+        "contentCreation": "Content Creation",
+        "newcomers": "Newcomers",
+        "content": "Content",
+        "documentation": "Documentation"
       },
       "roles": {
         "title": "Roles",

--- a/src/locales/en/hydra.json
+++ b/src/locales/en/hydra.json
@@ -71,7 +71,10 @@
         }
       }
     },
-    "videoTitle": "Play a video tutorial",
+    "video" : {
+      "title" : "Play a video tutorial",
+      "subtitle" : "Release the Hydra"
+    },
     "getStarted": {
       "title": "Get started with Hydra now!",
       "subtitle": "Use the following links to connect with us and find out even more.",

--- a/src/locales/en/roles.json
+++ b/src/locales/en/roles.json
@@ -3,6 +3,21 @@
     "siteMetadata": {
       "description": "Read more about current and future roles on the Joystream platform"
     },
+    "general" : {
+      "overview" : "Overview",
+      "responsibilities" : "Responsibilities",
+      "requirements" : "Requirements",
+      "seeATutorial" : "See a tutorial",
+      "askAQuestion" : "Ask a question",
+      "regularUpdates" : "Receive regular updates on the following role:",
+      "alertWhenActive" : "Alert me when the role will be active",
+      "emailAddressPlaceholder" : "Your email address",
+      "receiveEmailsAboutRole" : "I want to receive emails about this role.",
+      "informationTransferred" : "I acknowledge that my information will be transferred to Mailchimp, which has <0>these</0> privacy practices.",
+      "join" : "Join",
+      "subscribe" : "Subscribe",
+      "pleaseWait" : "Please wait.."
+    },
     "hero": {
       "title": "Choose your preferred role",
       "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."

--- a/src/locales/es/general.json
+++ b/src/locales/es/general.json
@@ -131,5 +131,12 @@
   "cookiesNotice": {
     "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
     "findOutMore": "Find out more ›"
+  },
+  "testnet" : {
+    "goalStates": {
+      "achieved" : "achieved",
+      "inProgress" : "in progress",
+      "postponed" : "postponed"
+    }
   }
 }

--- a/src/locales/es/get-started.json
+++ b/src/locales/es/get-started.json
@@ -30,7 +30,8 @@
         "design": "Design",
         "marketing": "Marketing",
         "research": "Research",
-        "contentCreation": "Content Creation"
+        "contentCreation": "Content Creation",
+        "newcomers": "Newcomers"
       },
       "roles": {
         "title": "Roles",

--- a/src/locales/es/hydra.json
+++ b/src/locales/es/hydra.json
@@ -71,7 +71,10 @@
         }
       }
     },
-    "videoTitle": "Play a video tutorial",
+    "video" : {
+      "title" : "Play a video tutorial",
+      "subtitle" : "Release the Hydra"
+    },
     "getStarted": {
       "title": "Get started with Hydra now!",
       "subtitle": "Use the following links to connect with us and find out even more.",

--- a/src/locales/es/roles.json
+++ b/src/locales/es/roles.json
@@ -3,6 +3,21 @@
     "siteMetadata": {
       "description": "Read more about current and future roles on the Joystream platform"
     },
+    "general" : {
+      "overview" : "Overview",
+      "responsibilities" : "Responsibilities",
+      "requirements" : "Requirements",
+      "seeATutorial" : "See a tutorial",
+      "askAQuestion" : "Ask a question",
+      "regularUpdates" : "Receive regular updates on the following role:",
+      "alertWhenActive" : "Alert me when the role will be active",
+      "emailAddressPlaceholder" : "Your email address",
+      "receiveEmailsAboutRole" : "I want to receive emails about this role.",
+      "informationTransferred" : "I acknowledge that my information will be transferred to Mailchimp, which has <0>these</0> privacy practices.",
+      "join" : "Join",
+      "subscribe" : "Subscribe",
+      "pleaseWait" : "Please wait.."
+    },
     "hero": {
       "title": "Choose your preferred role",
       "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."

--- a/src/locales/fr/general.json
+++ b/src/locales/fr/general.json
@@ -131,5 +131,12 @@
   "cookiesNotice": {
     "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
     "findOutMore": "Find out more ›"
+  },
+  "testnet" : {
+    "goalStates": {
+      "achieved" : "achieved",
+      "inProgress" : "in progress",
+      "postponed" : "postponed"
+    }
   }
 }

--- a/src/locales/fr/get-started.json
+++ b/src/locales/fr/get-started.json
@@ -30,7 +30,8 @@
         "design": "Design",
         "marketing": "Marketing",
         "research": "Research",
-        "contentCreation": "Content Creation"
+        "contentCreation": "Content Creation",
+        "newcomers": "Newcomers"
       },
       "roles": {
         "title": "Roles",

--- a/src/locales/fr/hydra.json
+++ b/src/locales/fr/hydra.json
@@ -71,7 +71,10 @@
         }
       }
     },
-    "videoTitle": "Play a video tutorial",
+    "video" : {
+      "title" : "Play a video tutorial",
+      "subtitle" : "Release the Hydra"
+    },
     "getStarted": {
       "title": "Get started with Hydra now!",
       "subtitle": "Use the following links to connect with us and find out even more.",

--- a/src/locales/fr/roles.json
+++ b/src/locales/fr/roles.json
@@ -3,6 +3,21 @@
     "siteMetadata": {
       "description": "Read more about current and future roles on the Joystream platform"
     },
+    "general" : {
+      "overview" : "Overview",
+      "responsibilities" : "Responsibilities",
+      "requirements" : "Requirements",
+      "seeATutorial" : "See a tutorial",
+      "askAQuestion" : "Ask a question",
+      "regularUpdates" : "Receive regular updates on the following role:",
+      "alertWhenActive" : "Alert me when the role will be active",
+      "emailAddressPlaceholder" : "Your email address",
+      "receiveEmailsAboutRole" : "I want to receive emails about this role.",
+      "informationTransferred" : "I acknowledge that my information will be transferred to Mailchimp, which has <0>these</0> privacy practices.",
+      "join" : "Join",
+      "subscribe" : "Subscribe",
+      "pleaseWait" : "Please wait.."
+    },
     "hero": {
       "title": "Choose your preferred role",
       "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."

--- a/src/locales/ru/general.json
+++ b/src/locales/ru/general.json
@@ -131,5 +131,12 @@
   "cookiesNotice": {
     "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
     "findOutMore": "Find out more ›"
+  },
+  "testnet" : {
+    "goalStates": {
+      "achieved" : "achieved",
+      "inProgress" : "in progress",
+      "postponed" : "postponed"
+    }
   }
 }

--- a/src/locales/ru/get-started.json
+++ b/src/locales/ru/get-started.json
@@ -30,7 +30,8 @@
         "design": "Design",
         "marketing": "Marketing",
         "research": "Research",
-        "contentCreation": "Content Creation"
+        "contentCreation": "Content Creation",
+        "newcomers": "Newcomers"
       },
       "roles": {
         "title": "Roles",

--- a/src/locales/ru/hydra.json
+++ b/src/locales/ru/hydra.json
@@ -71,7 +71,10 @@
         }
       }
     },
-    "videoTitle": "Play a video tutorial",
+    "video" : {
+      "title" : "Play a video tutorial",
+      "subtitle" : "Release the Hydra"
+    },
     "getStarted": {
       "title": "Get started with Hydra now!",
       "subtitle": "Use the following links to connect with us and find out even more.",

--- a/src/locales/ru/roles.json
+++ b/src/locales/ru/roles.json
@@ -3,6 +3,21 @@
     "siteMetadata": {
       "description": "Read more about current and future roles on the Joystream platform"
     },
+    "general" : {
+      "overview" : "Overview",
+      "responsibilities" : "Responsibilities",
+      "requirements" : "Requirements",
+      "seeATutorial" : "See a tutorial",
+      "askAQuestion" : "Ask a question",
+      "regularUpdates" : "Receive regular updates on the following role:",
+      "alertWhenActive" : "Alert me when the role will be active",
+      "emailAddressPlaceholder" : "Your email address",
+      "receiveEmailsAboutRole" : "I want to receive emails about this role.",
+      "informationTransferred" : "I acknowledge that my information will be transferred to Mailchimp, which has <0>these</0> privacy practices.",
+      "join" : "Join",
+      "subscribe" : "Subscribe",
+      "pleaseWait" : "Please wait.."
+    },
     "hero": {
       "title": "Choose your preferred role",
       "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."

--- a/src/locales/zh/general.json
+++ b/src/locales/zh/general.json
@@ -131,5 +131,12 @@
   "cookiesNotice": {
     "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
     "findOutMore": "Find out more ›"
+  },
+  "testnet" : {
+    "goalStates": {
+      "achieved" : "achieved",
+      "inProgress" : "in progress",
+      "postponed" : "postponed"
+    }
   }
 }

--- a/src/locales/zh/get-started.json
+++ b/src/locales/zh/get-started.json
@@ -30,7 +30,8 @@
         "design": "Design",
         "marketing": "Marketing",
         "research": "Research",
-        "contentCreation": "Content Creation"
+        "contentCreation": "Content Creation",
+        "newcomers": "Newcomers"
       },
       "roles": {
         "title": "Roles",

--- a/src/locales/zh/hydra.json
+++ b/src/locales/zh/hydra.json
@@ -71,7 +71,10 @@
         }
       }
     },
-    "videoTitle": "Play a video tutorial",
+    "video" : {
+      "title" : "Play a video tutorial",
+      "subtitle" : "Release the Hydra"
+    },
     "getStarted": {
       "title": "Get started with Hydra now!",
       "subtitle": "Use the following links to connect with us and find out even more.",

--- a/src/locales/zh/roles.json
+++ b/src/locales/zh/roles.json
@@ -3,6 +3,21 @@
     "siteMetadata": {
       "description": "Read more about current and future roles on the Joystream platform"
     },
+    "general" : {
+      "overview" : "Overview",
+      "responsibilities" : "Responsibilities",
+      "requirements" : "Requirements",
+      "seeATutorial" : "See a tutorial",
+      "askAQuestion" : "Ask a question",
+      "regularUpdates" : "Receive regular updates on the following role:",
+      "alertWhenActive" : "Alert me when the role will be active",
+      "emailAddressPlaceholder" : "Your email address",
+      "receiveEmailsAboutRole" : "I want to receive emails about this role.",
+      "informationTransferred" : "I acknowledge that my information will be transferred to Mailchimp, which has <0>these</0> privacy practices.",
+      "join" : "Join",
+      "subscribe" : "Subscribe",
+      "pleaseWait" : "Please wait.."
+    },
     "hero": {
       "title": "Choose your preferred role",
       "text": "Participating in a role on our testnet lets you earn tJOY while influencing the platform's ongoing development."

--- a/src/pages/athens/index.js
+++ b/src/pages/athens/index.js
@@ -94,7 +94,7 @@ const AthensPage = ({ content }) => {
         </TitleWrapper>
 
         <TitleWrapper
-          title="Testnet Goals"
+          title={t('athens.testnetGoals.title')}
           subtitle={
             <>
               <Trans

--- a/src/pages/brand/guides/index.js
+++ b/src/pages/brand/guides/index.js
@@ -31,8 +31,8 @@ const GuidesPage = () => {
             data={guidesData.sidebar.map(({ title, subSections, ...rest }) => {
               return {
                 title: t(`brand.guides.general.${convertToCamelCase(title)}`),
-                subSections: subSections?.map(({ subSectionTitle, ...subSectionRest }) => ({
-                  title: t(`brand.guides.general.${subSectionTitle}`),
+                subSections: subSections?.map(({ title: subsectionTitle, ...subSectionRest }) => ({
+                  title: t(`brand.guides.general.${convertToCamelCase(subsectionTitle)}`),
                   ...subSectionRest,
                 })),
                 ...rest,

--- a/src/pages/hydra/index.js
+++ b/src/pages/hydra/index.js
@@ -59,8 +59,8 @@ function HydraPage() {
         <Features features={content.Features.features} t={t}/>
       </LayoutWrapper>
       <LayoutWrapper className="Video">
-        <TitleWrapper title={t("hydra.videoTitle")} />
-        <Video src={content.Video.video.src} />
+        <TitleWrapper title={t("hydra.video.title")} />
+        <Video src={content.Video.video.src} subtitle={t("hydra.video.subtitle")} />
       </LayoutWrapper>
       <LayoutWrapper className="GetStarted">
         <TitleWrapper title={t("hydra.getStarted.title")} subtitle={<p>{t("hydra.getStarted.subtitle")}</p>} />

--- a/src/pages/roles/index.js
+++ b/src/pages/roles/index.js
@@ -108,7 +108,7 @@ const RolesPage = () => {
                 }}
                 key={role.title}
               >
-                <RoleOverview {...translateRolesData({ ...role }, t)} type={key} ref={elementsRef[role.id]} />
+                <RoleOverview t={t} {...translateRolesData({ ...role }, t)} type={key} ref={elementsRef[role.id]} />
               </InView>
             ));
           })}


### PR DESCRIPTION
Community members working on the Russian translation, namely @OIgnat and @katerina510, have found spots where either functionality or translations were missing and rounded those all up neatly in this [file](https://ignatusha-my.sharepoint.com/:w:/g/personal/alex_ihnatusha_pro/EVkVviwka75Aly89BcvNJR0Bbvhd2ZkfyvjoDS7PJZJhlw?rtime=_dnvGNxx2Ug).

I've gone through and implemented most of them. The two I didn't, I didn't for these reasons:
- Under point 6, I didn't translate those two words because those are names and I don't think it makes sense to translate them.
- For point 7, I've added translations and functionality for bounty card tags but titles and descriptions are also not really possible because the person making them would have to make them and for 5,6+ languages I think that is unrealistic to expect. Even if do decide to add this functionality we would take a different approach with it anyway.

