### PR TITLE
Fix formatDate utility function

### DIFF
--- a/src/utils/formatDate/index.js
+++ b/src/utils/formatDate/index.js
@@ -7,7 +7,7 @@ export default function formatDate(date) {
   if (month.length < 2) month = '0' + month;
   if (day.length < 2) day = '0' + day;
 
-  year = String(year).slice(0, 2);
+  year = String(year).slice(2);
 
   return [day, month, year].join('.');
 }


### PR DESCRIPTION
The `utils/formatDate` function cuts the first 2  characters of the year string instead of slicing the last 2. This PR addresses this issue. This has resulted in these fixes as well:
- Current founding members list on `/founding-members`.
- Pending cashouts on `/token`.
- Pending exchanges on `/testnet`.
- Dates on graphs on `/dashboard`.