### PR TITLE
Update bountiesLink

### DIFF
--- a/src/data/pages/get-started.js
+++ b/src/data/pages/get-started.js
@@ -38,4 +38,4 @@ export const roleCardData = {
     }
 }
 
-export const bountiesLink = 'https://raw.githubusercontent.com/Joystream/community-repo/master/bounties/overview/bounties-status.json';
+export const bountiesLink = 'https://raw.githubusercontent.com/Joystream/community-repo/master/bounties/bounties-status.json';


### PR DESCRIPTION
It was recently moved from `bounties/overview` to `bounties/`: https://github.com/Joystream/community-repo/pull/427