### PR TITLE
Fix links within website to work with translated pages

### DIFF
--- a/src/components/ArrowLink/index.js
+++ b/src/components/ArrowLink/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 import { ReactComponent as Arrow } from '../../assets/svg/arrow-down-small.svg';
 import cn from 'classnames';
 

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,4 +1,4 @@
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 import PropTypes from 'prop-types';
 import React from 'react';
 import cn from 'classnames';

--- a/src/components/Button/test.js
+++ b/src/components/Button/test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/src/components/Link/index.js
+++ b/src/components/Link/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { string, bool, node } from 'prop-types';
-import { Link as DefaultLink } from 'gatsby';
+import { Link as DefaultLink } from 'gatsby-plugin-react-i18next';
 import cn from 'classnames';
 import AnchorLink from 'react-anchor-link-smooth-scroll';
 

--- a/src/components/Link/test.js
+++ b/src/components/Link/test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link as DefaultLink } from 'gatsby';
+import { Link as DefaultLink } from 'gatsby-plugin-react-i18next';
 import { configure, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 

--- a/src/components/founding-members/Metrics/index.js
+++ b/src/components/founding-members/Metrics/index.js
@@ -152,7 +152,7 @@ const Metrics = ({ foundingMembers, nonFoundingMembers, sizeOfFirstTokenPool, t 
             </Table>
             <ArrowButton
               className="FoundingMembersPage__leaderboard__button"
-              link="/founding-members/leaderboards"
+              to="/founding-members/leaderboards"
               text={t('foundingMembers.landing.keyMetrics.foundingMembersButton')}
             />
           </div>

--- a/src/components/founding-members/ScoringPeriod/index.js
+++ b/src/components/founding-members/ScoringPeriod/index.js
@@ -119,7 +119,7 @@ const ScoringPeriod = ({ formerDate, latterDate, scoringPeriodId, t }) => {
         <div className="FoundingMembersPage__period__buttons">
           <ArrowButton
             className="FoundingMembersPage__period__summary-button"
-            link="/founding-members/form"
+            to="/founding-members/form"
             text={t('foundingMembers.scoringPeriod.submitSummary')}
           />
           <ArrowButton

--- a/src/components/index-page/BecomeFoundingMember/index.js
+++ b/src/components/index-page/BecomeFoundingMember/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ReactComponent as Arrow } from '../../../assets/svg/arrow-down-small.svg';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 
 import './style.scss';
 

--- a/src/components/index-page/EarnTokens/index.js
+++ b/src/components/index-page/EarnTokens/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 
 import { ReactComponent as BuilderCTA } from '../../../assets/svg/builder-cta.svg';
 import { ReactComponent as BuilderAlt } from '../../../assets/svg/builder-cta-alt.svg';

--- a/src/components/index-page/Hero/index.js
+++ b/src/components/index-page/Hero/index.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import { Trans } from 'gatsby-plugin-react-i18next';
+import { Trans, Link } from 'gatsby-plugin-react-i18next';
 import HeroImage from '../../../assets/svg/hero-builder.svg';
 import { ReactComponent as Arrow } from '../../../assets/svg/arrow-down-small.svg';
-import { Link } from 'gatsby';
 
 import './style.scss';
 

--- a/src/components/index-page/RoadToMainnet/index.js
+++ b/src/components/index-page/RoadToMainnet/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 import cn from 'classnames';
 
 import { ReactComponent as Arrow } from '../../../assets/svg/arrow-down-small.svg';

--- a/src/components/index-page/WhatWeDo/index.js
+++ b/src/components/index-page/WhatWeDo/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ReactComponent as Fist } from '../../../assets/svg/fist-bg2.svg';
 import { ReactComponent as FistAlt } from '../../../assets/svg/fist-bg2-alt.svg';
 import { ReactComponent as Arrow } from '../../../assets/svg/arrow-down-small.svg';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 
 import './style.scss';
 

--- a/src/components/index-page/WhyYouShouldJoin/index.js
+++ b/src/components/index-page/WhyYouShouldJoin/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 
 import { ReactComponent as Tokens } from '../../../assets/svg/joy-token.svg';
 import { ReactComponent as Money } from '../../../assets/svg/money-circle.svg';

--- a/src/data/pages/token.js
+++ b/src/data/pages/token.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'gatsby';
+import { Link } from 'gatsby-plugin-react-i18next';
 
 const tokenQuestions = [
     {

--- a/src/pages/founding-members/form/index.js
+++ b/src/pages/founding-members/form/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import SiteMetadata from '../../../components/SiteMetadata';
 import { graphql } from 'gatsby';
-import { useTranslation, useI18next, Trans } from 'gatsby-plugin-react-i18next';
+import { useTranslation, useI18next, Link } from 'gatsby-plugin-react-i18next';
 import BaseLayout from '../../../components/_layouts/Base';
 import { ReactComponent as Arrow } from '../../../assets/svg/arrow-down-small.svg';
 import { ScoringPeriodCounter } from '../../../components/founding-members/ScoringPeriod';
@@ -32,10 +32,10 @@ const FoundingMembersFormPage = () => {
       <div className="FoundingMembersFormPage">
         <div className="FoundingMembersFormPage__header">
           <div className="FoundingMembersFormPage__back">
-            <a href="/founding-members" className="FoundingMembersFormPage__back__text">
+            <Link to="/founding-members" className="FoundingMembersFormPage__back__text">
               <Arrow className="FoundingMembersFormPage__back__arrow" />
               <span>{t('foundingMembers.general.backButton')}</span>
-            </a>
+            </Link>
           </div>
           <div className="FoundingMembersFormPage__header__title-wrapper">
             <h1 className="FoundingMembersFormPage__header__title">{t('foundingMembers.form.title')}</h1>

--- a/src/pages/founding-members/leaderboards/index.js
+++ b/src/pages/founding-members/leaderboards/index.js
@@ -3,7 +3,7 @@ import cn from 'classnames';
 import { graphql } from 'gatsby';
 import { types } from '@joystream/types';
 import { ApiPromise, WsProvider } from '@polkadot/api';
-import { useTranslation, useI18next } from 'gatsby-plugin-react-i18next';
+import { useTranslation, useI18next , Link } from 'gatsby-plugin-react-i18next';
 
 import Table from '../../../components/Table';
 import SiteMetadata from '../../../components/SiteMetadata';
@@ -177,9 +177,9 @@ const Leaderboards = ({ location }) => {
         <div className="FoundingMembersLeaderboards__header-wrapper">
           <div className="FoundingMembersLeaderboards__back">
             <Arrow className="FoundingMembersLeaderboards__back__arrow" />
-            <a href="/founding-members" className="FoundingMembersLeaderboards__back__text">
+            <Link to="/founding-members" className="FoundingMembersLeaderboards__back__text">
               {t('foundingMembers.general.backButton')}
-            </a>
+            </Link>
           </div>
           <div className="FoundingMembersLeaderboards__header">
             <h1 className="FoundingMembersLeaderboards__header__title">{t('foundingMembers.leaderboards.title')}</h1>


### PR DESCRIPTION
This is the continuation of PR https://github.com/Joystream/joystream-org/pull/403 and final step to fully implementing translations into `joystream.org`. Before, one would need to add the locale identifier before the routes every time one visits a page on the website but now all the pages are connected and the locale is remembered.