### PR TITLE
Fix bounties error

### DIFF
--- a/src/components/get-started/Bounties/Carousel/index.js
+++ b/src/components/get-started/Bounties/Carousel/index.js
@@ -20,6 +20,7 @@ const parseDate = dateString => {
 };
 
 const BountiesCard = ({ title, amount, categories, date, id, link, description, t }) => {
+  console.log(t);
   return (
     <a className="GetStarted__bounties-carousel__card-wrapper-link" target="_blank" href={link ? link : '#'}>
       <div className="GetStarted__bounties-carousel__card">
@@ -193,6 +194,7 @@ const BountiesCarousel = ({ t }) => {
                       id={bounty?.id}
                       link={bounty?.links[0]}
                       description={bounty?.description}
+                      t={t}
                     />
                   );
                 }


### PR DESCRIPTION
Currently if a user clicks on one of the filters the whole site crashes. This is because a function was not being passed in the props of one of the BountyCards, probably something I missed when merging translation to master.

Changes:
- Pass function `t` to props of the second `BountiesCard` component in the carousel.