### PR TITLE
Update Cookie Notice and Privacy Policy (GDPR)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,13 +40,6 @@ module.exports = {
         trackingId: process.env.GA_ID,
       },
     },
-    {
-      resolve: 'gatsby-plugin-hotjar',
-      options: {
-        id: process.env.HJ_ID,
-        sv: process.env.HJ_SV,
-      },
-    },
     'gatsby-plugin-sass',
     {
       resolve: `gatsby-source-filesystem`,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "gatsby-image": "^2.2.1",
     "gatsby-plugin-anchor-links": "^1.1.1",
     "gatsby-plugin-google-analytics": "^2.1.0",
-    "gatsby-plugin-hotjar": "^1.0.1",
     "gatsby-plugin-manifest": "^2.2.0",
     "gatsby-plugin-offline": "^2.2.0",
     "gatsby-plugin-polyfill-io": "^1.1.0",

--- a/src/data/pages/privacy-policy.js
+++ b/src/data/pages/privacy-policy.js
@@ -36,6 +36,7 @@ const privacyPolicyItems = [
         <Link href="https://marketingplatform.google.com/about/analytics/">Google Analytics</Link>,
         <br />,
         <strong />,
+        <Link href="https://livesession.io/security/">Livesession</Link>
       ],
     },
   },

--- a/src/locales/en/general.json
+++ b/src/locales/en/general.json
@@ -129,7 +129,7 @@
     "discord": "Discord"
   },
   "cookiesNotice": {
-    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more ›"
   },
   "testnet" : {

--- a/src/locales/en/privacy-policy.json
+++ b/src/locales/en/privacy-policy.json
@@ -17,7 +17,7 @@
     },
     "privacyPolicyItems": {
       "title": "Privacy Policy",
-      "subtitle": "Last updated on the 17th of April 2019",
+      "subtitle": "Last updated on the 23rd of February 2022",
       "agreement": {
         "title": "1. Agreement to the Policy",
         "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
@@ -32,7 +32,7 @@
       },
       "googleAnalytics": {
         "title": "",
-        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> Company also uses <3>Livesession</3> to help us find bugs, improve UX and more by using session replays. Sensitive data such as passwords and IP addresses are anonymized. <1 /><1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
       }
     },
     "cookiePolicyItems": {

--- a/src/locales/es/general.json
+++ b/src/locales/es/general.json
@@ -129,7 +129,7 @@
     "discord": "Discord"
   },
   "cookiesNotice": {
-    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more ›"
   },
   "testnet" : {

--- a/src/locales/es/privacy-policy.json
+++ b/src/locales/es/privacy-policy.json
@@ -17,7 +17,7 @@
     },
     "privacyPolicyItems": {
       "title": "Privacy Policy",
-      "subtitle": "Last updated on the 17th of April 2019",
+      "subtitle": "Last updated on the 23rd of February 2022",
       "agreement": {
         "title": "1. Agreement to the Policy",
         "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
@@ -32,7 +32,7 @@
       },
       "googleAnalytics": {
         "title": "",
-        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> Company also uses <3>Livesession</3> to help us find bugs, improve UX and more by using session replays. Sensitive data such as passwords and IP addresses are anonymized. <1 /><1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
       }
     },
     "cookiePolicyItems": {

--- a/src/locales/fr/general.json
+++ b/src/locales/fr/general.json
@@ -129,7 +129,7 @@
     "discord": "Discord"
   },
   "cookiesNotice": {
-    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more ›"
   },
   "testnet" : {

--- a/src/locales/fr/privacy-policy.json
+++ b/src/locales/fr/privacy-policy.json
@@ -17,7 +17,7 @@
     },
     "privacyPolicyItems": {
       "title": "Privacy Policy",
-      "subtitle": "Last updated on the 17th of April 2019",
+      "subtitle": "Last updated on the 23rd of February 2022",
       "agreement": {
         "title": "1. Agreement to the Policy",
         "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
@@ -32,7 +32,7 @@
       },
       "googleAnalytics": {
         "title": "",
-        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> Company also uses <3>Livesession</3> to help us find bugs, improve UX and more by using session replays. Sensitive data such as passwords and IP addresses are anonymized. <1 /><1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
       }
     },
     "cookiePolicyItems": {

--- a/src/locales/ru/general.json
+++ b/src/locales/ru/general.json
@@ -129,7 +129,7 @@
     "discord": "Discord"
   },
   "cookiesNotice": {
-    "text": "Этот сайт использует файлы cookie. Продолжая использовать сайт, вы даете согласие на использование файлов cookie.",
+    "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Узнать больше ›"
   },
   "testnet" : {

--- a/src/locales/ru/privacy-policy.json
+++ b/src/locales/ru/privacy-policy.json
@@ -17,7 +17,7 @@
     },
     "privacyPolicyItems": {
       "title": "Политика Конфиденциальности",
-      "subtitle": "Последнее обновление 17 Апреля 2019",
+      "subtitle": "Last updated on the 23rd of February 2022",
       "agreement": {
         "title": "1. Согласие с Политикой",
         "content": "Используя любое Наше Программное обеспечение, Пользователь принимает настоящую Политику Конфиденциальности. Если Вы действуете от имени другой компании или работодателя, Вы должны иметь полномочия действовать от их имени. Политика Конфиденциальности не распространяется ни на одну нашу рассылку, где Пользователи связаны <0>политикой конфиденциальности</0> <1>Mailchimp</1><2/><2/>Политика Конфиденциальности не применяется к любым другим сторонним службам, включая, помимо прочего, приложения, веб-сайты, инструменты или программное обеспечение, даже если они доступны по ссылкам или руководствам к нашему Программному обеспечению."
@@ -32,7 +32,7 @@
       },
       "googleAnalytics": {
         "title": "",
-        "content": "Компания использует <0>Google Analytics</0> с анонимизацией IP-адресов для сбора статистики на Веб-сайте и в версии Приложения, размещенной у Нас. Все настраиваемые параметры обмена данными отключены для улучшения защиты конфиденциальности Пользователей. ‍<1/> <1/><2> Компания не будет продавать ваши данные в рекламных или других целях.</2>"
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> Company also uses <3>Livesession</3> to help us find bugs, improve UX and more by using session replays. Sensitive data such as passwords and IP addresses are anonymized. <1 /><1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
       }
     },
     "cookiePolicyItems": {

--- a/src/locales/zh/general.json
+++ b/src/locales/zh/general.json
@@ -129,7 +129,7 @@
     "discord": "Discord"
   },
   "cookiesNotice": {
-    "text": "This site uses cookies. By continuing to browse the site, you are agreeing to our use of cookies.",
+    "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more ›"
   },
   "testnet" : {

--- a/src/locales/zh/privacy-policy.json
+++ b/src/locales/zh/privacy-policy.json
@@ -17,7 +17,7 @@
     },
     "privacyPolicyItems": {
       "title": "Privacy Policy",
-      "subtitle": "Last updated on the 17th of April 2019",
+      "subtitle": "Last updated on the 23rd of February 2022",
       "agreement": {
         "title": "1. Agreement to the Policy",
         "content": "By using any of Our Software, the User are accepting this Privacy Policy. If you are acting on behalf of another company or an employer, you must have the rights to act on their behalf. The Privacy Policy is not extended to any of our newsletters, where Users are bound by the <0>privacy policy</0> of <1>Mailchimp</1><2/><2/>The Privacy Policy does not apply to any other third party services including, but not limited to, applications, websites, tools or software, even if accessible through links or guides in our Software."
@@ -32,7 +32,7 @@
       },
       "googleAnalytics": {
         "title": "",
-        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
+        "content": "Company uses <0>Google Analytics</0>, with IP anonymization, to collect statistics on Website and the version of App hosted by us. All customisable data sharing settings are turned off to improve the privacy of Users. ‍<1 />‍<1 /> Company also uses <3>Livesession</3> to help us find bugs, improve UX and more by using session replays. Sensitive data such as passwords and IP addresses are anonymized. <1 /><1 /> <2>Company will not sell your data for advertising, or other purposes.</2>"
       }
     },
     "cookiePolicyItems": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8769,13 +8769,6 @@ gatsby-plugin-google-analytics@^2.1.0:
     "@babel/runtime" "^7.12.5"
     minimatch "3.0.4"
 
-gatsby-plugin-hotjar@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-hotjar/-/gatsby-plugin-hotjar-1.1.1.tgz#b910209c80fb2a0df9e0dc1b52de7270d9831b31"
-  integrity sha512-zEuZuZPokvBZvfKg7W0MjPoydFnD8NqhgB0Rm32A7HTWu44vvH+UYt0NsvnyINYmICS9ftv+y/k3WAAzkAIUNw==
-  dependencies:
-    babel-runtime "^6.26.0"
-
 gatsby-plugin-manifest@^2.2.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.11.0.tgz#66d4b9c29a83211c289ef597f700bd089a399193"


### PR DESCRIPTION
This PR addresses the issue explained here: https://github.com/Joystream/joystream-org/issues/438

Changes:
- Remove gatsby `hotjar` plugin
- Remove hotjar from gatsby config
- Update cookie notice text
- Add paragraph about `Livesession` in `/privacy-policy`
- Update date in `/privacy-policy`