### PR TITLE
Update cookie setting process

### DIFF
--- a/__tests__/pages/__snapshots__/privacy-policy.test.js.snap
+++ b/__tests__/pages/__snapshots__/privacy-policy.test.js.snap
@@ -256,6 +256,13 @@ exports[`PrivacyPolicyPage page renders correctly 1`] = `
                 </Link>,
                 <br />,
                 <strong />,
+                <Link
+                  className=""
+                  highlighted={false}
+                  href="https://livesession.io/security/"
+                >
+                  Livesession
+                </Link>,
               ]
             }
             i18nKey="privacyPolicy.privacyPolicyItems.googleAnalytics.content"

--- a/src/components/CookiesNotice/index.js
+++ b/src/components/CookiesNotice/index.js
@@ -16,6 +16,8 @@ const defaultProps = {
   actionless: false,
 };
 
+const LAST_PRIVACY_POLICY_CHANGE_DATE_STRING = "2022-02-23T11:29:46.000Z";
+
 class CookiesNotice extends React.Component {
   constructor() {
     super();
@@ -29,8 +31,20 @@ class CookiesNotice extends React.Component {
   }
 
   componentDidMount() {
-    const isCookieSet = cookies.get(this.cookieName);
+    const cookieValue = cookies.get(this.cookieName);
     const { actionless } = this.props;
+
+    let cookieSetDate = null;
+    let isCookieSet = false;
+
+    if(Date.parse(cookieValue) !== NaN) {
+      cookieSetDate = new Date(cookieValue);
+    }
+
+    const lastPrivacyPolicyChangeDate = new Date(LAST_PRIVACY_POLICY_CHANGE_DATE_STRING);
+    if(cookieSetDate !== null && cookieSetDate > lastPrivacyPolicyChangeDate) {
+      isCookieSet = true;
+    }
 
     if (!actionless && isCookieSet) {
       this.setState({ visible: false });
@@ -41,8 +55,10 @@ class CookiesNotice extends React.Component {
     const { cookieName, expires } = this;
     const { actionless } = this.props;
 
+    const nowAsISOString = (new Date()).toISOString();
+
     if (!actionless) {
-      cookies.set(cookieName, true, expires);
+      cookies.set(cookieName, nowAsISOString, expires);
       this.setState({ visible: false });
     }
   };

--- a/src/utils/cookieHelper/index.js
+++ b/src/utils/cookieHelper/index.js
@@ -11,13 +11,17 @@ function set(name, value, days, doc = document) {
 }
 
 function get(name, doc = document) {
-  const nameEQ = `${name}=`;
-  const ca = doc.cookie.split(';');
-  for (let i = 0; i < ca.length; i += 1) {
-    let c = ca[i];
-    while (c.charAt(0) === ' ') c = c.substring(1, c.length);
-    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length, c.length);
+  const joystreamCookiePrefix = `${name}=`;
+  const cookies = doc.cookie.split(';');
+
+  for (const cookie of cookies) {
+    const trimmedCookie = cookie.trimLeft();
+
+    if(trimmedCookie.indexOf(joystreamCookiePrefix) == 0) {
+      return trimmedCookie.substring(joystreamCookiePrefix.length);
+    }
   }
+
   return null;
 }
 


### PR DESCRIPTION
Since the cookies need to be reset every time the privacy policy is updated, this code changes the current cookie setting functionality to save a date in the cookie value and compare it to the date of the last time the privacy policy has been altered.

This change originated from this issue: https://github.com/Joystream/joystream-org/issues/438#issuecomment-1050781096