### PR TITLE
Tweaks

### DIFF
--- a/src/components/Footer/data.js
+++ b/src/components/Footer/data.js
@@ -7,7 +7,6 @@ import { sharedData } from '../../data/pages';
 const joystreamLinks = [
   { href: sharedData.links.blog, label: 'pages.blog' },
   { to: '/manifesto', label: 'pages.manifesto' },
-  { href: 'https://joystream.gitbook.io/testnet-workspace/usdjoy', label: 'pages.token' },
   { to: '/hydra', label: 'pages.hydra' },
 ];
 

--- a/src/components/Navbar/data.js
+++ b/src/components/Navbar/data.js
@@ -1,6 +1,7 @@
 import { sharedData } from '../../data/pages';
 
 const links = [
+  { to: '/lightpaper.pdf', label: 'navbar.lightpaper' },
   { to: '/about', label: 'navbar.about' },
   { to: '/community', label: 'navbar.community' },
   { to: '/token', label: 'navbar.token' },

--- a/src/components/Navbar/data.js
+++ b/src/components/Navbar/data.js
@@ -6,11 +6,6 @@ const links = [
   { to: '/token', label: 'navbar.token' },
   { href: 'https://dao.joystream.org', label: 'navbar.pioneer' },
   { to: '/manifesto', label: 'navbar.manifesto' },
-  {
-    to: '/#apps-built-on-joystream',
-    label: 'navbar.viewApps',
-    isButton: true,
-  },
 ];
 
 export { links };

--- a/src/components/Navbar/data.js
+++ b/src/components/Navbar/data.js
@@ -1,7 +1,8 @@
 import { sharedData } from '../../data/pages';
 
 const links = [
-  { to: '/lightpaper.pdf', label: 'navbar.lightpaper' },
+  // Language "en" is a workaround to disallow gatsby to route to language specific routes here (e.g. ru/lightpaper.pdf)
+  { to: '/lightpaper.pdf', label: 'navbar.lightpaper', language: 'en' },
   { to: '/about', label: 'navbar.about' },
   { to: '/community', label: 'navbar.community' },
   { to: '/token', label: 'navbar.token' },

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -94,7 +94,7 @@ const NavbarLinksSection = ({ t, links, isScrollUp, isOpen, light, setIsOpen }) 
           'Navbar__links--light': light,
         })}
       >
-        {links.map(({ label, isButton, isDropdown, links, href, to }) => {
+        {links.map(({ label, isButton, isDropdown, links, href, to, language }) => {
           if (isDropdown) {
             return <Dropdown key={label} t={t} label={t(label)} links={links} isScrollUp={isScrollUp} />;
           }
@@ -111,9 +111,11 @@ const NavbarLinksSection = ({ t, links, isScrollUp, isOpen, light, setIsOpen }) 
 
           if (isButton) {
             children = (
-              <div className={cn("Navbar__button", {
-                "Navbar__button--light": light
-              })} >
+              <div
+                className={cn('Navbar__button', {
+                  'Navbar__button--light': light,
+                })}
+              >
                 <p className="Navbar__button-text">{t(label)}</p>
                 <Arrow className="Navbar__button-arrow" />
               </div>
@@ -121,7 +123,7 @@ const NavbarLinksSection = ({ t, links, isScrollUp, isOpen, light, setIsOpen }) 
           }
 
           return (
-            <Link key={label} to={to} href={href}>
+            <Link key={label} to={to} href={href} language={language}>
               {children}
             </Link>
           );
@@ -148,29 +150,53 @@ const NavbarPrimerSection = ({ t }) => {
     document.getElementById(sectionIdName).scrollIntoView({
       behavior: 'smooth',
     });
-  } 
+  }
 
   // PRIMER TODO: These seem to be wrong, clear it up with the team.
 
   return (
     <div className="Navbar__primer-section">
       <div className="Navbar__primer-section__section-items">
-        <p className="Navbar__primer-section__section-item" role="presentation" onClick={() => goToSection(sectionIDs[1])}>
+        <p
+          className="Navbar__primer-section__section-item"
+          role="presentation"
+          onClick={() => goToSection(sectionIDs[1])}
+        >
           {t('primer.navbar.futureOfVideo')}
         </p>
-        <p className="Navbar__primer-section__section-item" role="presentation" onClick={() => goToSection(sectionIDs[2])}>
+        <p
+          className="Navbar__primer-section__section-item"
+          role="presentation"
+          onClick={() => goToSection(sectionIDs[2])}
+        >
           {t('primer.navbar.whyWeExist')}
         </p>
-        <p className="Navbar__primer-section__section-item" role="presentation" onClick={() => goToSection(sectionIDs[3])}>
+        <p
+          className="Navbar__primer-section__section-item"
+          role="presentation"
+          onClick={() => goToSection(sectionIDs[3])}
+        >
           {t('primer.navbar.theSolution')}
         </p>
-        <p className="Navbar__primer-section__section-item" role="presentation" onClick={() => goToSection(sectionIDs[4])}>
+        <p
+          className="Navbar__primer-section__section-item"
+          role="presentation"
+          onClick={() => goToSection(sectionIDs[4])}
+        >
           {t('primer.navbar.governance')}
         </p>
-        <p className="Navbar__primer-section__section-item" role="presentation" onClick={() => goToSection(sectionIDs[5])}>
+        <p
+          className="Navbar__primer-section__section-item"
+          role="presentation"
+          onClick={() => goToSection(sectionIDs[5])}
+        >
           {t('primer.navbar.businessModel')}
         </p>
-        <p className="Navbar__primer-section__section-item" role="presentation" onClick={() => goToSection(sectionIDs[6])}>
+        <p
+          className="Navbar__primer-section__section-item"
+          role="presentation"
+          onClick={() => goToSection(sectionIDs[6])}
+        >
           {t('primer.navbar.nextSteps')}
         </p>
       </div>
@@ -190,8 +216,15 @@ const Navbar = ({ light, links, t, primer }) => {
   const shouldRenderPrimerSection = primer != null;
 
   return (
-    <nav className={cn('Navbar', { 'Navbar--hidden': !isScrollUp, 'Navbar--light': light, 'Navbar--open': isOpen, 'Navbar--primer': primer })}>
-      <div className={cn("Navbar__container", { "Navbar__container--primer": primer })}>
+    <nav
+      className={cn('Navbar', {
+        'Navbar--hidden': !isScrollUp,
+        'Navbar--light': light,
+        'Navbar--open': isOpen,
+        'Navbar--primer': primer,
+      })}
+    >
+      <div className={cn('Navbar__container', { 'Navbar__container--primer': primer })}>
         <Link to="/">
           <Logo className={cn('Navbar__logo', { 'Navbar__logo--open': isOpen })} />
         </Link>
@@ -199,7 +232,14 @@ const Navbar = ({ light, links, t, primer }) => {
         {shouldRenderPrimerSection ? (
           <NavbarPrimerSection t={t} />
         ) : (
-          <NavbarLinksSection t={t} links={links} isScrollUp={isScrollUp} isOpen={isOpen} light={light} setIsOpen={setIsOpen} />
+          <NavbarLinksSection
+            t={t}
+            links={links}
+            isScrollUp={isScrollUp}
+            isOpen={isOpen}
+            light={light}
+            setIsOpen={setIsOpen}
+          />
         )}
       </div>
     </nav>

--- a/src/components/_layouts/Base/index.js
+++ b/src/components/_layouts/Base/index.js
@@ -5,7 +5,6 @@ import Navbar from '../../Navbar';
 import Footer from '../../Footer';
 import CookiesNotice from '../../CookiesNotice';
 import { ScrollProvider } from '../../_enhancers/ScrollContext';
-import MainnetBanner from '../../MainnetBanner';
 
 const propTypes = {
   children: node,
@@ -20,13 +19,10 @@ const BaseLayout = ({ children, t, mainnetReminder = true, primer, lightNavbar }
   return (
     <ScrollProvider>
       <div>
-        {mainnetReminder ? <MainnetBanner t={t} light={lightNavbar} /> : null}
         <Navbar t={t} primer={primer} light={lightNavbar} />
-        <main>
-          {children}
-        </main>
-        <CookiesNotice t={t}/>
-        <Footer t={t} primer={primer}/>
+        <main>{children}</main>
+        <CookiesNotice t={t} />
+        <Footer t={t} primer={primer} />
       </div>
     </ScrollProvider>
   );

--- a/src/locales/en/general.json
+++ b/src/locales/en/general.json
@@ -22,10 +22,10 @@
     "discoveryProvider": "Discovery Provider",
     "bandwidthProvider": "Bandwidth Provider",
     "builder": "Builder",
-    "storageLead" : "Storage Lead",
-    "contentLead" : "Content Lead",
-    "membershipCurator" : "Membership Curator",
-    "communicationModerator" : "Communication Moderator"
+    "storageLead": "Storage Lead",
+    "contentLead": "Content Lead",
+    "membershipCurator": "Membership Curator",
+    "communicationModerator": "Communication Moderator"
   },
   "siteMetadata": {
     "title": "Joystream: The video platform DAO"
@@ -100,7 +100,8 @@
     "viewApps": "View apps",
     "community": "Community",
     "about": "About",
-    "token": "Token"
+    "token": "Token",
+    "lightpaper": "Lightpaper"
   },
   "footer": {
     "title": "Stay up to date",
@@ -145,11 +146,11 @@
     "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more →"
   },
-  "testnet" : {
+  "testnet": {
     "goalStates": {
-      "achieved" : "achieved",
-      "inProgress" : "in progress",
-      "postponed" : "postponed"
+      "achieved": "achieved",
+      "inProgress": "in progress",
+      "postponed": "postponed"
     }
   },
   "mainnetBanner": {

--- a/src/locales/es/general.json
+++ b/src/locales/es/general.json
@@ -22,10 +22,10 @@
     "discoveryProvider": "Discovery Provider",
     "bandwidthProvider": "Bandwidth Provider",
     "builder": "Builder",
-    "storageLead" : "Storage Lead",
-    "contentLead" : "Content Lead",
-    "membershipCurator" : "Membership Curator",
-    "communicationModerator" : "Communication Moderator"
+    "storageLead": "Storage Lead",
+    "contentLead": "Content Lead",
+    "membershipCurator": "Membership Curator",
+    "communicationModerator": "Communication Moderator"
   },
   "siteMetadata": {
     "title": "Joystream: The video platform DAO"
@@ -100,7 +100,8 @@
     "viewApps": "View apps",
     "community": "Community",
     "about": "About",
-    "token": "Token"
+    "token": "Token",
+    "lightpaper": "Lightpaper"
   },
   "footer": {
     "title": "Stay up to date",
@@ -145,11 +146,11 @@
     "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more →"
   },
-  "testnet" : {
+  "testnet": {
     "goalStates": {
-      "achieved" : "achieved",
-      "inProgress" : "in progress",
-      "postponed" : "postponed"
+      "achieved": "achieved",
+      "inProgress": "in progress",
+      "postponed": "postponed"
     }
   },
   "mainnetBanner": {

--- a/src/locales/fr/general.json
+++ b/src/locales/fr/general.json
@@ -22,10 +22,10 @@
     "discoveryProvider": "Discovery Provider",
     "bandwidthProvider": "Bandwidth Provider",
     "builder": "Builder",
-    "storageLead" : "Storage Lead",
-    "contentLead" : "Content Lead",
-    "membershipCurator" : "Membership Curator",
-    "communicationModerator" : "Communication Moderator"
+    "storageLead": "Storage Lead",
+    "contentLead": "Content Lead",
+    "membershipCurator": "Membership Curator",
+    "communicationModerator": "Communication Moderator"
   },
   "siteMetadata": {
     "title": "Joystream: The video platform DAO"
@@ -100,7 +100,8 @@
     "viewApps": "View apps",
     "community": "Community",
     "about": "About",
-    "token": "Token"
+    "token": "Token",
+    "lightpaper": "Lightpaper"
   },
   "footer": {
     "title": "Stay up to date",
@@ -145,11 +146,11 @@
     "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more →"
   },
-  "testnet" : {
+  "testnet": {
     "goalStates": {
-      "achieved" : "achieved",
-      "inProgress" : "in progress",
-      "postponed" : "postponed"
+      "achieved": "achieved",
+      "inProgress": "in progress",
+      "postponed": "postponed"
     }
   },
   "mainnetBanner": {

--- a/src/locales/ru/general.json
+++ b/src/locales/ru/general.json
@@ -22,10 +22,10 @@
     "discoveryProvider": "Провайдер обнаружения",
     "bandwidthProvider": "Провайдер пропускной способности",
     "builder": "Разработчик",
-    "storageLead" : "Главный провайдер хранилищ",
-    "contentLead" : "Главный куратор контента",
-    "membershipCurator" : "Membership Curator",
-    "communicationModerator" : "Communication Moderator"
+    "storageLead": "Главный провайдер хранилищ",
+    "contentLead": "Главный куратор контента",
+    "membershipCurator": "Membership Curator",
+    "communicationModerator": "Communication Moderator"
   },
   "siteMetadata": {
     "title": "Joystream: видеоплатформа DAO"
@@ -100,7 +100,8 @@
     "viewApps": "View apps",
     "community": "Community",
     "about": "About",
-    "token": "Token"
+    "token": "Token",
+    "lightpaper": "Lightpaper"
   },
   "footer": {
     "title": "Следите за новостями",
@@ -145,11 +146,11 @@
     "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more →"
   },
-  "testnet" : {
+  "testnet": {
     "goalStates": {
-      "achieved" : "достигнуто",
-      "inProgress" : "в процессе",
-      "postponed" : "отложено"
+      "achieved": "достигнуто",
+      "inProgress": "в процессе",
+      "postponed": "отложено"
     }
   },
   "mainnetBanner": {

--- a/src/locales/zh/general.json
+++ b/src/locales/zh/general.json
@@ -22,10 +22,10 @@
     "discoveryProvider": "Discovery Provider",
     "bandwidthProvider": "Bandwidth Provider",
     "builder": "Builder",
-    "storageLead" : "Storage Lead",
-    "contentLead" : "Content Lead",
-    "membershipCurator" : "Membership Curator",
-    "communicationModerator" : "Communication Moderator"
+    "storageLead": "Storage Lead",
+    "contentLead": "Content Lead",
+    "membershipCurator": "Membership Curator",
+    "communicationModerator": "Communication Moderator"
   },
   "siteMetadata": {
     "title": "Joystream: The video platform DAO"
@@ -100,7 +100,8 @@
     "viewApps": "View apps",
     "community": "Community",
     "about": "About",
-    "token": "Token"
+    "token": "Token",
+    "lightpaper": "Lightpaper"
   },
   "footer": {
     "title": "Stay up to date",
@@ -145,11 +146,11 @@
     "text": "This site uses cookies and external trackers to improve our services and your experience. By continuing to use our site, you agree to their use.",
     "findOutMore": "Find out more →"
   },
-  "testnet" : {
+  "testnet": {
     "goalStates": {
-      "achieved" : "achieved",
-      "inProgress" : "in progress",
-      "postponed" : "postponed"
+      "achieved": "achieved",
+      "inProgress": "in progress",
+      "postponed": "postponed"
     }
   },
   "mainnetBanner": {


### PR DESCRIPTION
PR aims to implement feature requests outlined in this issue: https://github.com/Joystream/joystream-org/issues/597

Changes:
- Add lightpaper link to navbar
- Removed "View apps" navbar button.
- Remove "We're on mainnet" banner

Questions:
- With regards to the first point in the issue, from what I can tell handbook (on its own) was never really part of the footer. Specific parts have however (e.g. we currently link to: https://joystream.gitbook.io/testnet-workspace/security). Did you perhaps mean to put it back in the navbar? If not, we can definitely put it in the footer, would just like to make sure.
- The Lightpaper link has been added to the navbar but it is not a thing yet. Would need the pdf shared with me!
- The view apps button has been removed. Do we want to replace it with anything or do we keep everything as is?
- I also remember us talking about the token link in the footer before. Do we also want to update that? Maybe link to the new token page now?

cc @bedeho, can't tag you as reviewer unfortunately..