### PR TITLE
Fix token page wallet section logo placement

### DIFF
--- a/src/components/token-page/Wallets/index.js
+++ b/src/components/token-page/Wallets/index.js
@@ -16,7 +16,7 @@ const WalletSection = ({ walletIcon, walletName, walletLink, t }) => {
         <img src={walletIcon} className="TokenPage__wallets__item__image" alt="" />
       </div>
       <p className="TokenPage__wallets__item__name">{walletName}</p>
-      <ArrowLink href={walletLink} className="TokenPage__wallets__item__link" text={t("token.wallets.learnMore")} />
+      <ArrowLink href={walletLink} className="TokenPage__wallets__item__link" text={t('token.wallets.learnMore')} />
     </div>
   );
 };
@@ -26,26 +26,34 @@ const Wallets = ({ t }) => {
     <section className="TokenPage__wallets-wrapper">
       <div className="TokenPage__wallets">
         <header className="TokenPage__wallets__header">
-          <span className="TokenPage__wallets__header__section-title">{t("token.wallets.sectionTitle")}</span>
-          <h2 className="TokenPage__wallets__header__title">{t("token.wallets.title")}</h2>
-          <p className="TokenPage__wallets__header__subtitle">
-            {t("token.wallets.subtitle")}
-          </p>
+          <span className="TokenPage__wallets__header__section-title">{t('token.wallets.sectionTitle')}</span>
+          <h2 className="TokenPage__wallets__header__title">{t('token.wallets.title')}</h2>
+          <p className="TokenPage__wallets__header__subtitle">{t('token.wallets.subtitle')}</p>
         </header>
 
         <div className="TokenPage__wallets__items">
           <WalletSection
             walletIcon={PolkadotIcon}
-            walletName={t("token.wallets.polkadot")}
+            walletName={t('token.wallets.polkadot')}
             walletLink="https://polkadot.js.org/extension/"
             t={t}
           />
-          <WalletSection walletIcon={SubWalletIcon} walletName={t("token.wallets.talisman")} walletLink="https://www.talisman.xyz/" t={t} />
-          <WalletSection walletIcon={TalismanIcon} walletName={t("token.wallets.subwallet")} walletLink="https://subwallet.app/" t={t} />
+          <WalletSection
+            walletIcon={TalismanIcon}
+            walletName={t('token.wallets.talisman')}
+            walletLink="https://www.talisman.xyz/"
+            t={t}
+          />
+          <WalletSection
+            walletIcon={SubWalletIcon}
+            walletName={t('token.wallets.subwallet')}
+            walletLink="https://subwallet.app/"
+            t={t}
+          />
         </div>
         <div className="TokenPage__wallets__info">
           <InfoIcon className="TokenPage__wallets__info__icon" />
-          {t("token.wallets.info")}
+          {t('token.wallets.info')}
         </div>
       </div>
     </section>


### PR DESCRIPTION
As mentioned by user kanbeok#7308 on discord ([url](https://discord.com/channels/811216481340751934/815192060276506664/1094380125866434623)), the logos for subwallet and talisman are not in the correct positions. This PR aims to fix this.