### PR TITLE
Asset optimization

### DIFF
--- a/src/components/index-page/Payouts/index.js
+++ b/src/components/index-page/Payouts/index.js
@@ -5,6 +5,7 @@ import { Trans, useI18next } from 'gatsby-plugin-react-i18next';
 
 import { parseDateToRelativeTime, getDateHoursAgo } from '../../../utils/pages/landing/parseDateToRelativeTime';
 import useRemoveElementFocusOnKeydown from '../../../utils/useRemoveElementFocusOnKeydown';
+import useImageFallback from '../../../utils/useImageFallback';
 
 // import { ArrowButton } from '../../ArrowButton';
 
@@ -53,37 +54,35 @@ const parallaxDataForeground = [
   },
 ];
 
-const CarouselItem = ({ img, joyAmount, channelName, time, setIsCarouselRunning, channelUrl }) => (
-  <a href={channelUrl} target="_blank" rel="noreferrer">
-    <div
-      className="IndexPage__payouts-carousel__item"
-      onMouseEnter={() => setIsCarouselRunning(true)}
-      onMouseLeave={() => setIsCarouselRunning(false)}
-    >
-      <div className="IndexPage__payouts-carousel__item__image">
-        <img
-          src={img}
-          onError={e => {
-            e.currentTarget.src = PlaceholderIcon;
-          }}
-          alt=""
-        />
-      </div>
-      <div className="IndexPage__payouts-carousel__item__price">
-        <PlusIcon className="IndexPage__payouts-carousel__item__price__icon" />
-        <div className="IndexPage__payouts-carousel__item__price__text">
-          <Trans i18nKey="landing.payouts.carousel.item.price" components={{ span: <span />, joyAmount }} />
+const CarouselItem = ({ img, joyAmount, channelName, time, setIsCarouselRunning, channelUrl }) => {
+  const [imgSrc, onError] = useImageFallback(img, PlaceholderIcon);
+
+  return (
+    <a href={channelUrl} target="_blank" rel="noreferrer">
+      <div
+        className="IndexPage__payouts-carousel__item"
+        onMouseEnter={() => setIsCarouselRunning(true)}
+        onMouseLeave={() => setIsCarouselRunning(false)}
+      >
+        <div className="IndexPage__payouts-carousel__item__image">
+          <img src={imgSrc} onError={e => onError(e)} alt="" />
+        </div>
+        <div className="IndexPage__payouts-carousel__item__price">
+          <PlusIcon className="IndexPage__payouts-carousel__item__price__icon" />
+          <div className="IndexPage__payouts-carousel__item__price__text">
+            <Trans i18nKey="landing.payouts.carousel.item.price" components={{ span: <span />, joyAmount }} />
+          </div>
+        </div>
+        <div className="IndexPage__payouts-carousel__item__channel">
+          <Trans i18nKey="landing.payouts.carousel.item.channel" components={{ span: <span />, channelName }} />
+        </div>
+        <div className="IndexPage__payouts-carousel__item__time">
+          <ClockIcon className="IndexPage__payouts-carousel__item__time__icon" /> {time}
         </div>
       </div>
-      <div className="IndexPage__payouts-carousel__item__channel">
-        <Trans i18nKey="landing.payouts.carousel.item.channel" components={{ span: <span />, channelName }} />
-      </div>
-      <div className="IndexPage__payouts-carousel__item__time">
-        <ClockIcon className="IndexPage__payouts-carousel__item__time__icon" /> {time}
-      </div>
-    </div>
-  </a>
-);
+    </a>
+  );
+};
 
 const Carousel = ({ itemsData, t }) => {
   const [isCarouselRunning, setIsCarouselRunning] = useState(false);

--- a/src/components/index-page/VideoNFTs/index.js
+++ b/src/components/index-page/VideoNFTs/index.js
@@ -5,6 +5,7 @@ import { Trans, useI18next } from 'gatsby-plugin-react-i18next';
 
 import { parseDateToRelativeTime, getDateHoursAgo } from '../../../utils/pages/landing/parseDateToRelativeTime';
 import useRemoveElementFocusOnKeydown from '../../../utils/useRemoveElementFocusOnKeydown';
+import useImageFallback from '../../../utils/useImageFallback';
 
 import VideoNFTsBackgroundImage from '../../../assets/images/landing/video-nfts-background.webp';
 import VideoNFTsForegroundImage from '../../../assets/images/landing/video-nfts-foreground.webp';
@@ -48,48 +49,52 @@ const parallaxDataPopup = [
   },
 ];
 
-const CarouselItem = ({ nftTitle, channelName, joyAmount, videoUrl, imageUrl, time, setIsCarouselRunning, t }) => (
-  <a href={videoUrl} target="_blank" rel="noreferrer">
-    <div
-      className="IndexPage__video-nfts-carousel__item"
-      onMouseEnter={() => setIsCarouselRunning(true)}
-      onMouseLeave={() => setIsCarouselRunning(false)}
-    >
-      <div className="IndexPage__video-nfts-carousel__item__image">
-        <img src={imageUrl} alt="" />
-      </div>
-      <div className="IndexPage__video-nfts-carousel__item__content">
-        <div className="IndexPage__video-nfts-carousel__item__content__title">
-          <Trans
-            i18nKey="landing.videoNFTs.carousel.item.title"
-            components={{
-              span: <span />,
-              nftTitle,
-              channelName,
-            }}
-          />
+const CarouselItem = ({ nftTitle, channelName, joyAmount, videoUrl, imageUrls, time, setIsCarouselRunning, t }) => {
+  const [imgSrc, onError] = useImageFallback(imageUrls);
+
+  return (
+    <a href={videoUrl} target="_blank" rel="noreferrer">
+      <div
+        className="IndexPage__video-nfts-carousel__item"
+        onMouseEnter={() => setIsCarouselRunning(true)}
+        onMouseLeave={() => setIsCarouselRunning(false)}
+      >
+        <div className="IndexPage__video-nfts-carousel__item__image">
+          <img src={imgSrc} alt="" onError={e => onError(e)} />
         </div>
-        <div className="IndexPage__video-nfts-carousel__item__content__price">
-          <div className="IndexPage__video-nfts-carousel__item__content__price__title">
-            {t('landing.videoNFTs.carousel.item.price.label')}
-          </div>
-          <div className="IndexPage__video-nfts-carousel__item__content__price__amount">
+        <div className="IndexPage__video-nfts-carousel__item__content">
+          <div className="IndexPage__video-nfts-carousel__item__content__title">
             <Trans
-              i18nKey="landing.videoNFTs.carousel.item.price.amount"
+              i18nKey="landing.videoNFTs.carousel.item.title"
               components={{
                 span: <span />,
-                joyAmount,
+                nftTitle,
+                channelName,
               }}
             />
           </div>
-        </div>
-        <div className="IndexPage__video-nfts-carousel__item__content__time">
-          <ClockIcon className="IndexPage__video-nfts-carousel__item__content__time__icon" /> {time}
+          <div className="IndexPage__video-nfts-carousel__item__content__price">
+            <div className="IndexPage__video-nfts-carousel__item__content__price__title">
+              {t('landing.videoNFTs.carousel.item.price.label')}
+            </div>
+            <div className="IndexPage__video-nfts-carousel__item__content__price__amount">
+              <Trans
+                i18nKey="landing.videoNFTs.carousel.item.price.amount"
+                components={{
+                  span: <span />,
+                  joyAmount,
+                }}
+              />
+            </div>
+          </div>
+          <div className="IndexPage__video-nfts-carousel__item__content__time">
+            <ClockIcon className="IndexPage__video-nfts-carousel__item__content__time__icon" /> {time}
+          </div>
         </div>
       </div>
-    </div>
-  </a>
-);
+    </a>
+  );
+};
 
 const Carousel = ({ itemsData, t }) => {
   const [isCarouselRunning, setIsCarouselRunning] = useState(false);
@@ -101,7 +106,7 @@ const Carousel = ({ itemsData, t }) => {
       channelName={channelName}
       joyAmount={joyAmount}
       videoUrl={videoUrl}
-      imageUrl={imageUrl}
+      imageUrls={imageUrl}
       time={time}
       setIsCarouselRunning={setIsCarouselRunning}
       t={t}

--- a/src/utils/useImageFallback/index.js
+++ b/src/utils/useImageFallback/index.js
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+const useImageFallback = (imageList, placeholder) => {
+  const [imgData, setImgData] = useState({
+    src: imageList.length === 0 ? '' : imageList[0],
+    index: 0,
+  });
+
+  const onError = e => {
+    console.log('Error happened!');
+
+    if (imageList.length === 0 || imgData.index === imageList.length - 1) {
+      if (placeholder) {
+        e.currentTarget.src = placeholder;
+      }
+
+      return;
+    }
+
+    setImgData(prev => ({
+      src: imageList[prev.index + 1],
+      index: prev.index + 1,
+    }));
+  };
+
+  return [imgData.src, onError];
+};
+
+export default useImageFallback;

--- a/src/utils/useImageFallback/index.js
+++ b/src/utils/useImageFallback/index.js
@@ -2,14 +2,14 @@ import React, { useState } from 'react';
 
 const useImageFallback = (imageList, placeholder) => {
   const [imgData, setImgData] = useState({
-    src: imageList.length === 0 ? '' : imageList[0],
+    src: imageList?.length === 0 ? '' : imageList[0],
     index: 0,
   });
 
   const onError = e => {
     console.log('Error happened!');
 
-    if (imageList.length === 0 || imgData.index === imageList.length - 1) {
+    if (imageList === undefined || imageList.length === 0 || imgData.index === imageList.length - 1) {
       if (placeholder) {
         e.currentTarget.src = placeholder;
       }

--- a/src/utils/useImageFallback/index.js
+++ b/src/utils/useImageFallback/index.js
@@ -7,8 +7,6 @@ const useImageFallback = (imageList, placeholder) => {
   });
 
   const onError = e => {
-    console.log('Error happened!');
-
     if (imageList === undefined || imageList.length === 0 || imgData.index === imageList.length - 1) {
       if (placeholder) {
         e.currentTarget.src = placeholder;


### PR DESCRIPTION
This PR aims to fix the problem of fetching assets from distributors that have since stopped distributing or stopped working for whatever other reason. 

Currently on the landing page:
<img width="1454" alt="Screenshot 2023-07-05 at 09 20 09" src="https://github.com/Joystream/joystream-org/assets/26174828/9bbaa2d5-e402-417c-960d-9bbc0e7ffd13">

The idea is to return an array of possible assets from the status server and then locally choose the ones that work. The reasoning behind this is that the asset URLs validity can go stale between when the data is created by that api and fetched by the website. This aims to minimize the problem as much as possible.