### PR TITLE
Add exchanges id to token page exchanges section

### DIFF
--- a/src/components/token-page/Exchanges/index.js
+++ b/src/components/token-page/Exchanges/index.js
@@ -21,7 +21,7 @@ const ExchangeSection = ({ exchangeIcon, exchangeName, exchangeDescription, exch
 
 const Exchanges = ({ t }) => {
   return (
-    <section className="TokenPage__exchanges-wrapper">
+    <section className="TokenPage__exchanges-wrapper" id="exchanges">
       <div className="TokenPage__exchanges">
         <header className="TokenPage__exchanges__header">
           <span className="TokenPage__exchanges__header__section-title">{t('token.exchanges.sectionTitle')}</span>


### PR DESCRIPTION
Change:
- Add exchanges id to the top of the token page exchanges section to be used as a part of a link for a new pioneer feature.