### PR TITLE
Fix landing page typewriter bug

### DIFF
--- a/src/components/index-page/Hero/style.scss
+++ b/src/components/index-page/Hero/style.scss
@@ -28,7 +28,7 @@
       animation-delay: .1s;
 
       span > div {
-        display: inline-block;
+        display: -webkit-inline-box;
       }
     }
 
@@ -279,8 +279,13 @@
     &__hero__title {
       max-width: 335px;
 
-      span > div {
+      span {
         display: block;
+        max-height: 48px;
+      }
+
+      span > div {
+        display: -webkit-inline-box;
       }
     }
   }


### PR DESCRIPTION
This PR aims to fix the problem presented in this issue: https://github.com/Joystream/joystream-org/issues/655

Context: This seems to be a problem with Chrome. After doing testing on Firefox and Safari this title was rendered correctly. Even Chrome worked properly at the time of the initial implementation so it's probably a bug that was introduced in the last month or so (for which I've filed a bug report). The current fix is a workaround and uses a deprecated property to get the same effect, there shouldn't be any problems with this but I think it's just worth mentioning.