### PR TITLE
Fix council election bug

### DIFF
--- a/src/components/dashboard-page/Team/CurrentCouncil/index.js
+++ b/src/components/dashboard-page/Team/CurrentCouncil/index.js
@@ -23,7 +23,8 @@ const CurrentCouncil = ({ data }) => {
   const daysInService = data?.termLength;
   const nextElectionDate = data?.nextElectionDate || new Date();
 
-  const daysLeftToNextElection = getDaysLeftToNextElection(nextElectionDate);
+  const daysLeftToNextElection =
+    getDaysLeftToNextElection(nextElectionDate) < 0 ? 0 : getDaysLeftToNextElection(nextElectionDate);
   const remainingDaysInServicePercentage = Math.round((daysLeftToNextElection / daysInService) * 100);
 
   return (


### PR DESCRIPTION
Fixes bug that resulted in UI showing negative days until the next council election.

Image of bug for reference:
![Screenshot_2024-03-27_at_19 16 09](https://github.com/Joystream/joystream-org/assets/26174828/1fe69903-6cfd-425e-86ba-8136a5073e19)
