### PR TITLE
Remove ROI and Supply Distribution tables from Dashboard

### DIFF
--- a/src/components/dashboard-page/Token/index.js
+++ b/src/components/dashboard-page/Token/index.js
@@ -96,14 +96,14 @@ const Token = ({ data, loading }) => {
           </div>
         )}
 
-        {loading || (!data?.roi && !data?.supplyDistribution) ? (
+        {/* {loading || (!data?.roi && !data?.supplyDistribution) ? (
           <RoiSupplyBlockSkeleton />
         ) : (
           <div className="dashboard-token__stats-tables-grid grid-indents">
             <RoiTableWidget data={data?.roi} />
             <SupplyDistributionTableWidget data={data?.supplyDistribution} />
           </div>
-        )}
+        )} */}
       </div>
     </section>
   );


### PR DESCRIPTION
Reference issue: https://github.com/Joystream/joystream-org/issues/840