### PR TITLE
fix: remove reward carousel in payouts

### DIFF
--- a/src/components/index-page/Payouts/index.js
+++ b/src/components/index-page/Payouts/index.js
@@ -142,47 +142,6 @@ const Payouts = ({ t, payouts, priceData }) => {
           </Plx>
         </div>
       </div>
-      <div className="IndexPage__payouts__carousel-title-and-info-wrapper">
-        <div className="IndexPage__payouts__carousel-title-and-info">
-          <h3 className="IndexPage__payouts__carousel-title-and-info__title">{t('landing.payouts.carousel.title')}</h3>
-          <div className="IndexPage__payouts__carousel-title-and-info__info">
-            <div
-              className="IndexPage__payouts__carousel-title-and-info__info__label"
-              // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-              tabIndex={0}
-              aria-describedby="IndexPage__payouts__carousel-title-and-info__info__modal"
-              ref={payoutsCarouselInfoLabelRef}
-            >
-              {t('landing.payouts.carousel.info.label')}
-              <div className="IndexPage__payouts__carousel-title-and-info__info__icon">
-                <InfoIcon />
-              </div>
-            </div>
-            <div
-              role="tooltip"
-              id="IndexPage__payouts__carousel-title-and-info__info__modal"
-              className="IndexPage__payouts__carousel-title-and-info__info__modal"
-            >
-              <Trans i18nKey={'landing.payouts.carousel.info.text'} components={{ exchanges: <Link to="/token#exchanges" /> } } />
-            </div>
-          </div>
-        </div>
-      </div>
-      <section className="IndexPage__payouts-carousel">
-        <div className="IndexPage__payouts-carousel__items-wrapper">
-          {payouts && payouts.length > 0 ? (
-            <Carousel
-              itemsData={payouts?.map(({ createdAt, imageUrl, ...rest }) => ({
-                img: imageUrl,
-                time: parseDateToRelativeTime(createdAt, language),
-                ...rest,
-              }))}
-              priceData={priceData}
-              t={t}
-            />
-          ) : null}
-        </div>
-      </section>
     </section>
   );
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,10 +13,10 @@ import CreatorTokens from '../components/index-page/CreatorTokens';
 import JoystreamDAO from '../components/index-page/JoystreamDAO';
 // import AvailableActivities from '../components/index-page/AvailableActivities';
 import Ecosystem from '../components/index-page/Ecosystem';
-import Tokenomics from '../components/index-page/Tokenomics';
+// import Tokenomics from '../components/index-page/Tokenomics';
 import Video from '../components/index-page/Video';
 import Traction from '../components/index-page/Traction';
-import Upcoming from '../components/index-page/Upcoming';
+// import Upcoming from '../components/index-page/Upcoming';
 import Creators from '../components/index-page/Creators';
 import Dashboard from './dashboard';
 
@@ -57,7 +57,7 @@ const IndexPage = pageProps => {
 
       <CreatorTokens t={t} />
 
-      <Upcoming t={t} />
+      {/* <Upcoming t={t} /> */}
 
       <JoystreamDAO t={t} proposalsData={data?.carouselData.proposals} />
 


### PR DESCRIPTION
ref: #864

resolved the second issue : `The Joystream Creators section is redundant and is repeated in the Recent rewards from the Joystream DAO`