### PR TITLE
Change explorer link in the footer

### DIFF
--- a/src/components/Footer/data.js
+++ b/src/components/Footer/data.js
@@ -18,7 +18,7 @@ const githubLinks = [{ href: sharedData.links.repository, label: 'footer.github.
 const usefulLinks = [
   { href: 'https://joystream.gitbook.io/testnet-workspace/security', label: 'footer.security', icon: SecurityIcon },
   { href: 'https://polkadot.js.org/apps/?rpc=wss://rpc.joystream.org:9944#/explorer', label: 'footer.chainDashboard' },
-  { href: 'https://joystream.subscan.io/', label: 'footer.blockExplorer' },
+  { href: 'https://explorer.joystream.org/', label: 'footer.blockExplorer' },
   { to: '/brand/guides', label: 'footer.usefulLinks.brandGuidance' },
   { to: '/privacy-policy', label: 'footer.usefulLinks.privacyPolicy' },
 ];


### PR DESCRIPTION
https://joystream.subscan.io/ => https://explorer.joystream.org/

Subscan is no longer available.